### PR TITLE
Sconce and Brazier fuel fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ We supply 4 different versions of V+ with every release since version 0.8. You c
 
 ## **[Server] Windows**
 
-[Easy to setup and ready to use ValheimPlus servers can be rented here at Zap hosting !](https://zap-hosting.com/valheimplus)
+[Easy to setup and ready to use ValheimPlus servers can be rented here at ZAP-Hosting.com !](https://zap-hosting.com/valheimplus)
 
 We will not explain how you create a dedicated server. This will only explain how you install the mod.
 
@@ -185,7 +185,7 @@ We will not explain how you create a dedicated server. This will only explain ho
 
 ## **[Server] Unix**
 
-[Easy to setup and ready to use ValheimPlus servers can be rented here at Zap hosting !](https://zap-hosting.com/valheimplus)
+[Easy to setup and ready to use ValheimPlus servers can be rented here at ZAP-Hosting.com !](https://zap-hosting.com/valheimplus)
 
 We will not explain how you create a dedicated server. This will only explain how you install the mod.
 1. Download the [latest package called UnixServer.zip over this link](https://github.com/nxPublic/ValheimPlus/releases/latest/). *(Scroll down and click "assets")*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A HarmonyX Mod aimed at improving the gameplay quality of Valheim. The mod includes several different main features including modifiers to ingame stats of players, buildings and entities and a sophisticated system to build and place objects with high precision and a system to modify already placed objects with high precision. The general goal is to provide V+ as a base modification for your gameplay to increase quality of life, change difficulty or have a better experience in general. The mod also comes with a version and configuration control system for servers and users, allowing servers to make sure that only people with the same configuration are able to join their servers.
 
 # ValheimPlus Server Hosting
-Below you can find a list of hosting companies hosting and supporting ValehimPlus at good prices, high reliability and easy installation.
+Below you can find a list of hosting companies that are supporting ValehimPlus with good prices and easy installation.
 
 [![ValheimPlus Logo](http://valheimplus.com/zap/692x127.jpg)](https://zap-hosting.com/valheimplus)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,18 @@
 # ValheimPlus
 A HarmonyX Mod aimed at improving the gameplay quality of Valheim. The mod includes several different main features including modifiers to ingame stats of players, buildings and entities and a sophisticated system to build and place objects with high precision and a system to modify already placed objects with high precision. The general goal is to provide V+ as a base modification for your gameplay to increase quality of life, change difficulty or have a better experience in general. The mod also comes with a version and configuration control system for servers and users, allowing servers to make sure that only people with the same configuration are able to join their servers.
 
+# ValheimPlus Server Hosting
+Below you can find a list of hosting companies hosting and supporting ValehimPlus at good prices, high reliability and easy installation.
+
+[![ValheimPlus Logo](http://valheimplus.com/zap/692x127.jpg)](https://zap-hosting.com/valheimplus)
+
+If you are interested in being in this list, please contact us via Discord, GitHub, Nexus or via e-mail at "contact@valheim.plus".
+
+*(We do not agree to exclusive deals.)*
+
 # Features
 All of these features can be adjusted by a configuration file. This also allows you to only enable very specific featues.
+
 
 ## Player
 
@@ -163,7 +173,10 @@ We supply 4 different versions of V+ with every release since version 0.8. You c
 
 ## **[Server] Windows**
 
+[Easy to setup and ready to use ValheimPlus servers can be rented here at Zap hosting !](https://zap-hosting.com/valheimplus)
+
 We will not explain how you create a dedicated server. This will only explain how you install the mod.
+
 1. Download the [latest package called WindowsServer.zip over this link](https://github.com/nxPublic/ValheimPlus/releases/latest/). *(Scroll down and click "assets")*
 2. Unpack the downloaded zip file it into your root server folder.
 
@@ -171,6 +184,8 @@ We will not explain how you create a dedicated server. This will only explain ho
 
 
 ## **[Server] Unix**
+
+[Easy to setup and ready to use ValheimPlus servers can be rented here at Zap hosting !](https://zap-hosting.com/valheimplus)
 
 We will not explain how you create a dedicated server. This will only explain how you install the mod.
 1. Download the [latest package called UnixServer.zip over this link](https://github.com/nxPublic/ValheimPlus/releases/latest/). *(Scroll down and click "assets")*

--- a/ValheimPlus/Fireplace.cs
+++ b/ValheimPlus/Fireplace.cs
@@ -9,24 +9,23 @@ namespace ValheimPlus
         [HarmonyPatch(typeof(Fireplace), "UpdateFireplace")]
         public static class TorchesNoFuel 
         {
-            private static void Postfix(Fireplace __instance, ref ZNetView ___m_nview) 
-            {
-                if (Configuration.Current.Fireplace.IsEnabled)
-		{
-			if (Configuration.Current.Fireplace.onlyTorches)
-	                {
-		                if (__instance.GetHoverText().Contains("torch") || __instance.GetHoverText().Contains("Sconce") || __instance.name.Contains("brazier")) 
-                        	{
-                            		___m_nview.GetZDO().Set("fuel", 1f);
-                        	}  
-	                } 
-			else
-                    	{
-                        	___m_nview.GetZDO().Set("fuel", 3f);
-                    	}
-	            }
-
-            }
+			private static void Postfix(Fireplace __instance, ref ZNetView ___m_nview) 
+			{
+				if (Configuration.Current.Fireplace.IsEnabled)
+				{
+					if (Configuration.Current.Fireplace.onlyTorches)
+					{
+						if (__instance.GetHoverText().Contains("torch") || __instance.GetHoverText().Contains("Sconce") || __instance.name.Contains("brazier")) 
+						{
+							___m_nview.GetZDO().Set("fuel", 1f);
+						}  
+					} 
+					else
+					{
+						___m_nview.GetZDO().Set("fuel", 3f);
+					}
+				}
+			}
         }
     }
 }

--- a/ValheimPlus/Fireplace.cs
+++ b/ValheimPlus/Fireplace.cs
@@ -12,18 +12,18 @@ namespace ValheimPlus
             private static void Postfix(Fireplace __instance, ref ZNetView ___m_nview) 
             {
                 if (Configuration.Current.Fireplace.IsEnabled)
-	            {
-		            if (Configuration.Current.Fireplace.onlyTorches)
+		{
+			if (Configuration.Current.Fireplace.onlyTorches)
 	                {
-		                if (__instance.GetHoverText().Contains("torch") || __instance.GetHoverText().Contains("Scounce") || __instance.GetHoverText().Contains("brazier")) 
-                        {
-                            ___m_nview.GetZDO().Set("fuel", 1f);
-                        }  
+		                if (__instance.GetHoverText().Contains("torch") || __instance.GetHoverText().Contains("Sconce") || __instance.name.Contains("brazier")) 
+                        	{
+                            		___m_nview.GetZDO().Set("fuel", 1f);
+                        	}  
 	                } 
-                    else
-                    {
-                        ___m_nview.GetZDO().Set("fuel", 3f);
-                    }
+			else
+                    	{
+                        	___m_nview.GetZDO().Set("fuel", 3f);
+                    	}
 	            }
 
             }


### PR DESCRIPTION
Reason:
Sconce was spelled incorrectly and the brazier hover text was not "brazier" but "Fire", preventing the fuel set on update from working on these two items. 

Actions:
Corrected the spelling from "Scounce" to "Sconce".
Using instance name for the Hanging Brazier instead of hover text.