### PR TITLE
Show all portals on map with their respective names

### DIFF
--- a/ValheimPlus/Configurations/Sections/MapConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/MapConfiguration.cs
@@ -7,5 +7,6 @@
         public bool playerPositionPublicOnJoin { get; internal set; } = false;
         public bool preventPlayerFromTurningOffPublicPosition { get; internal set; } = false;
         public bool removeDeathPinOnTombstoneEmpty { get; internal set; } = false;
+        public bool showPortalsOnMap { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/TeleporterOnMap.cs
+++ b/ValheimPlus/TeleporterOnMap.cs
@@ -244,7 +244,7 @@ namespace ValheimPlus
                 return;
             }
 
-            if (Configuration.Current.Map.showPortalsOnMap)
+            if (Configuration.Current.Map.IsEnabled && Configuration.Current.Map.showPortalsOnMap)
             {
                 ZLog.Log("Sending message to server to trigger delivery of map icons");
                 ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
@@ -264,7 +264,7 @@ namespace ValheimPlus
                 return;
             }
 
-            if (Configuration.Current.Map.showPortalsOnMap)
+            if (Configuration.Current.Map.IsEnabled && Configuration.Current.Map.showPortalsOnMap)
             {
                 List<Minimap.PinData> copy;
 

--- a/ValheimPlus/TeleporterOnMap.cs
+++ b/ValheimPlus/TeleporterOnMap.cs
@@ -15,7 +15,8 @@ namespace ValheimPlus
         private static void Prefix()
         {
             //Config Sync
-            ZRoutedRpc.instance.Register(nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4), new Action<long, ZPackage>(VPlusTeleporterSync.RPC_VPlusTeleporterSync));
+            ZRoutedRpc.instance.Register(nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
+                new Action<long, ZPackage>(VPlusTeleporterSync.RPC_VPlusTeleporterSync));
         }
     }
 
@@ -26,14 +27,9 @@ namespace ValheimPlus
         public static List<Minimap.PinData> addedPins = new List<Minimap.PinData>();
 
         // Helper to create PinData objects without adding them to the map
-        public static Minimap.PinData AddPinHelper(
-            Vector3 pos,
-            Minimap.PinType type,
-            string name,
-            bool save,
-            bool isChecked)
+        public static Minimap.PinData AddPinHelper(Vector3 pos, Minimap.PinType type, string name, bool save, bool isChecked)
         {
-            Minimap.PinData pinData = new Minimap.PinData();
+            var pinData = new Minimap.PinData();
             pinData.m_type = type;
             pinData.m_name = name;
             pinData.m_pos = pos;
@@ -50,19 +46,19 @@ namespace ValheimPlus
             if (ZNet.instance.IsServer())
             {
                 // Create package and send it to all clients
-                ZPackage package = new ZPackage();
+                var package = new ZPackage();
 
                 // Collect all portal locations/names
-                List<ZDO> connected = new List<ZDO>();
-                Dictionary<string, ZDO> unconnected = new Dictionary<string, ZDO>();
+                var connected = new List<ZDO>();
+                var unconnected = new Dictionary<string, ZDO>();
 
-                foreach (List<ZDO> zdoarray in ZDOMan.instance.m_objectsBySector)
+                foreach (var zdoarray in ZDOMan.instance.m_objectsBySector)
                 {
                     if (zdoarray != null)
                     {
-                        foreach (ZDO zdo in zdoarray.Where(x => x.m_prefab == -661882940))
+                        foreach (var zdo in zdoarray.Where(x => x.m_prefab == -661882940))
                         {
-                            string tag = zdo.GetString("tag");
+                            var tag = zdo.GetString("tag");
 
                             if (!unconnected.ContainsKey(tag))
                             {
@@ -74,7 +70,6 @@ namespace ValheimPlus
                                 connected.Add(unconnected[tag]);
                                 unconnected.Remove(tag);
                             }
-
                         }
                     }
                 }
@@ -97,8 +92,9 @@ namespace ValheimPlus
                 if (teleporterZPackage == null)
                 {
                     ZLog.Log("Sending portal information to client (new peer)");
+
                     // Send to single client (on new connections only)
-                    ZRoutedRpc.instance.InvokeRoutedRPC(sender, nameof(RPC_VPlusTeleporterSync).Substring(4), new object[] { package });
+                    ZRoutedRpc.instance.InvokeRoutedRPC(sender, nameof(RPC_VPlusTeleporterSync).Substring(4), package);
                 }
                 else
                 {
@@ -108,7 +104,7 @@ namespace ValheimPlus
                         if (!peer.m_server)
                         {
                             // Send to all clients
-                            ZRoutedRpc.instance.InvokeRoutedRPC(peer.m_uid, nameof(RPC_VPlusTeleporterSync).Substring(4), new object[] { package });
+                            ZRoutedRpc.instance.InvokeRoutedRPC(peer.m_uid, nameof(RPC_VPlusTeleporterSync).Substring(4), package);
                         }
                     }
                 }
@@ -119,22 +115,22 @@ namespace ValheimPlus
             {
                 if (teleporterZPackage != null && teleporterZPackage.Size() > 0 && sender == ZRoutedRpc.instance.GetServerPeerID())
                 {
-                    int numConnectedPortals = teleporterZPackage.ReadInt();
+                    var numConnectedPortals = teleporterZPackage.ReadInt();
 
-                    Dictionary<Vector3, string> checkList = new Dictionary<Vector3, string>();
+                    var checkList = new Dictionary<Vector3, string>();
 
                     // prevent MT crashing
                     lock (addedPins)
                     {
                         while (numConnectedPortals > 0)
                         {
-                            Vector3 portalPosition = teleporterZPackage.ReadVector3();
-                            string portalName = teleporterZPackage.ReadString();
+                            var portalPosition = teleporterZPackage.ReadVector3();
+                            var portalName = teleporterZPackage.ReadString();
 
                             checkList.Add(portalPosition, portalName);
 
                             // Was pin already added?
-                            Minimap.PinData foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
+                            var foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
                             if (foundPin != null)
                             {
                                 // Did the pin's name change?
@@ -154,17 +150,17 @@ namespace ValheimPlus
                             numConnectedPortals--;
                         }
 
-                        int numUnconnectedPortals = teleporterZPackage.ReadInt();
+                        var numUnconnectedPortals = teleporterZPackage.ReadInt();
 
                         while (numUnconnectedPortals > 0)
                         {
-                            Vector3 portalPosition = teleporterZPackage.ReadVector3();
-                            string portalName = teleporterZPackage.ReadString();
+                            var portalPosition = teleporterZPackage.ReadVector3();
+                            var portalName = teleporterZPackage.ReadString();
 
                             checkList.Add(portalPosition, portalName);
 
                             // Was pin already added?
-                            Minimap.PinData foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
+                            var foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
                             if (foundPin != null)
                             {
                                 // Did the pin's name change?
@@ -200,11 +196,9 @@ namespace ValheimPlus
     }
 
 
-
-
     // React to setting tag on portal
     // Send special Chatmessage to server
-    [HarmonyPatch(typeof(TeleportWorld), "RPC_SetTag", new Type[] { typeof(long), typeof(string) })]
+    [HarmonyPatch(typeof(TeleportWorld), "RPC_SetTag", typeof(long), typeof(string))]
     public static class SyncTeleporterOnMap1
     {
         public static void Postfix(TeleportWorld __instance, long sender, string tag)
@@ -215,7 +209,7 @@ namespace ValheimPlus
             }
 
             // Force sending ZDO to server
-            ZDO temp = __instance.m_nview.GetZDO();
+            var temp = __instance.m_nview.GetZDO();
 
             ZDOMan.instance.GetZDO(temp.m_uid);
 
@@ -224,10 +218,11 @@ namespace ValheimPlus
             {
                 // Wait for ZDO to be sent else server won't have accurate information to send back
                 Thread.Sleep(5000);
+
                 // Send trigger to server
                 ZLog.Log("Sending message to server to trigger delivery of map icons after renaming portal");
                 ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
-                    new object[] { new ZPackage() });
+                    new ZPackage());
             });
         }
     }
@@ -248,7 +243,7 @@ namespace ValheimPlus
             {
                 ZLog.Log("Sending message to server to trigger delivery of map icons");
                 ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
-                    new object[] {new ZPackage()});
+                    new ZPackage());
             }
         }
     }
@@ -275,7 +270,7 @@ namespace ValheimPlus
 
                 foreach (var pin in copy)
                 {
-                    Minimap.PinData foundPin = Minimap.instance.m_pins.FirstOrDefault(x => x.m_pos == pin.m_pos);
+                    var foundPin = Minimap.instance.m_pins.FirstOrDefault(x => x.m_pos == pin.m_pos);
 
                     if (foundPin == null)
                     {

--- a/ValheimPlus/TeleporterOnMap.cs
+++ b/ValheimPlus/TeleporterOnMap.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HarmonyLib;
+using UnityEngine;
+
+namespace ValheimPlus
+{
+    // React to setting tag on portal
+    // Send special Chatmessage to server
+    [HarmonyPatch(typeof(TeleportWorld), "RPC_SetTag", new Type[] { typeof(long), typeof(string) })]
+    public static class SyncTeleporterOnMap1
+    {
+        public static void Postfix(TeleportWorld __instance, long sender, string tag)
+        {
+            if (ZNet.instance.IsServer())
+            {
+                return;
+            }
+            ZDO temp = __instance.m_nview.GetZDO();
+
+            ZDOMan.instance.GetZDO(temp.m_uid);
+
+            foreach (ZDOMan.ZDOPeer peer in ZDOMan.instance.m_peers)
+            {
+                peer.ForceSendZDO(temp.m_uid);
+            }
+
+            // I used the ChatMessage RPC since this is one of the few calls which are received/processed on the server and can be issued on client
+            ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.Everybody, "ChatMessage", new object[] { Player.m_localPlayer.GetHeadPoint(), 2, "SERVER", "PORTALUPDATE" });
+        }
+    }
+
+
+    // Receive special chat message from client
+    // Force sending new LocationIcons to all clients for map update
+    //
+    // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+    // Prevent further execution, if it is a special message (name == "SERVER", text == "PORTALUPDATE")
+    // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
+    [HarmonyPatch(typeof(Chat), "RPC_ChatMessage", new Type[] { typeof(long), typeof(Vector3), typeof(int), typeof(string), typeof(string) })]
+    public static class SyncTeleporterOnMap2
+    {
+        public static bool Prefix(Chat __instance, long sender, string name, string text)
+        {
+            if (text == "PORTALUPDATE" && name == "SERVER")
+            {
+                if (ZNet.instance.IsServer())
+                {
+                    Task.Factory.StartNew(() =>
+                    {
+                        Thread.Sleep(5000);
+                        foreach (var peer in ZNet.instance.m_peers)
+                        {
+                            if (!peer.m_server)
+                            {
+                                ZoneSystem.instance.SendLocationIcons(peer.m_uid);
+                            }
+                        }
+                    });
+                }
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    // Hook GetLocationIcons and add all portal locations with prefix "PORTAL"
+    [HarmonyPatch(typeof(ZoneSystem), "GetLocationIcons", new Type[] { typeof(Dictionary<Vector3, string>) })]
+    public static class SyncTeleporterOnMap3
+    {
+        // Only serverside
+        public static void Prefix(ref ZoneSystem __instance, ref Dictionary<Vector3, string> icons)
+        {
+            if (!ZNet.instance.IsServer())
+            {
+                return;
+            }
+
+            List<ZDO> connected = new List<ZDO>();
+            Dictionary<string, ZDO> unconnected = new Dictionary<string, ZDO>();
+
+            foreach (List<ZDO> zdoarray in ZDOMan.instance.m_objectsBySector)
+            {
+                if (zdoarray != null)
+                {
+                    foreach (ZDO zdo in zdoarray.Where(x => x.m_prefab == -661882940))
+                    {
+                        string tag = zdo.GetString("tag");
+
+                        if (!unconnected.ContainsKey(tag))
+                        {
+                            unconnected.Add(tag, zdo);
+                        }
+                        else
+                        {
+                            connected.Add(zdo);
+                            connected.Add(unconnected[tag]);
+                            unconnected.Remove(tag);
+                        }
+
+                    }
+                }
+            }
+
+            // Add icons for connected portals
+            // prefix connected names with a *
+            foreach (var zdo in connected)
+            {
+                icons[zdo.m_position] = "PORTAL* " + zdo.GetString("tag");
+            }
+
+            // Add icons for unconnected portals
+            // no prefix
+            foreach (var zdo in unconnected.Values)
+            {
+                icons[zdo.m_position] = "PORTAL" + zdo.GetString("tag");
+            }
+        }
+
+        // Holder for our pins
+        private static List<Minimap.PinData> addedPins;
+
+        // only client-side
+        public static void Postfix(ref ZoneSystem __instance, ref Dictionary<Vector3, string> icons)
+        {
+            if (!ZNet.instance.IsServer())
+            {
+                if (addedPins == null)
+                {
+                    addedPins = new List<Minimap.PinData>();
+                }
+
+                Dictionary<Vector3, string> checkList = new Dictionary<Vector3, string>();
+                
+                // Add all portal 'icons' to our checklist
+                foreach (var key in icons.Keys.ToArray())
+                {
+                    if (icons[key].StartsWith("PORTAL"))
+                    {
+                        checkList.Add(key, icons[key].Substring(6));
+                        icons.Remove(key);
+                    }
+                }
+
+                foreach (var kv in checkList)
+                {
+                    // Was pin already added?
+                    Minimap.PinData foundPin = addedPins.FirstOrDefault(x => x.m_pos == kv.Key);
+                    if (foundPin != null)
+                    {
+                        // Did the pin's name change?
+                        if (foundPin.m_name != kv.Value)
+                        {
+                            // Remove pin at location and readd with new name
+                            Minimap.instance.RemovePin(foundPin);
+                            addedPins.Remove(foundPin);
+                            addedPins.Add(Minimap.instance.AddPin(kv.Key, Minimap.PinType.Icon4, kv.Value, false, false));
+                        }
+                    }
+                    else
+                    {
+                        // Add new pin
+                        addedPins.Add(Minimap.instance.AddPin(kv.Key, Minimap.PinType.Icon4, kv.Value, false, false));
+                    }
+                }
+
+                // Remove destroyed portals from map
+                // doesn't really react on portal destruction, only works if after a portal was destroyed, someone set the name on another portal
+                foreach (var kv in addedPins.ToList())
+                {
+                    if (checkList.All(x => x.Key != kv.m_pos))
+                    {
+                        Minimap.instance.RemovePin(kv);
+                        addedPins.Remove(kv);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ValheimPlus/TeleporterOnMap.cs
+++ b/ValheimPlus/TeleporterOnMap.cs
@@ -8,6 +8,199 @@ using UnityEngine;
 
 namespace ValheimPlus
 {
+    [HarmonyPatch(typeof(Game), "Start")]
+    public static class GameStartPatchSyncTeleporterOnMap
+    {
+        private static void Prefix()
+        {
+            //Config Sync
+            ZRoutedRpc.instance.Register(nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4), new Action<long, ZPackage>(VPlusTeleporterSync.RPC_VPlusTeleporterSync));
+        }
+    }
+
+
+    public class VPlusTeleporterSync
+    {
+        // Holder for our pins
+        public static List<Minimap.PinData> addedPins = new List<Minimap.PinData>();
+
+        public static Minimap.PinData AddPinHelper(
+            Vector3 pos,
+            Minimap.PinType type,
+            string name,
+            bool save,
+            bool isChecked)
+        {
+            Minimap.PinData pinData = new Minimap.PinData();
+            pinData.m_type = type;
+            pinData.m_name = name;
+            pinData.m_pos = pos;
+            pinData.m_icon = Minimap.instance.GetSprite(type);
+            pinData.m_save = save;
+            pinData.m_checked = isChecked;
+            return pinData;
+        }
+
+
+        public static void RPC_VPlusTeleporterSync(long sender, ZPackage teleporterZPackage)
+        {
+            // SERVER SIDE
+            if (ZNet.instance.IsServer())
+            {
+                // Create package and send it to all clients
+                ZPackage package = new ZPackage();
+
+                // Collect all portal locations/names
+                List<ZDO> connected = new List<ZDO>();
+                Dictionary<string, ZDO> unconnected = new Dictionary<string, ZDO>();
+
+                foreach (List<ZDO> zdoarray in ZDOMan.instance.m_objectsBySector)
+                {
+                    if (zdoarray != null)
+                    {
+                        foreach (ZDO zdo in zdoarray.Where(x => x.m_prefab == -661882940))
+                        {
+                            string tag = zdo.GetString("tag");
+
+                            if (!unconnected.ContainsKey(tag))
+                            {
+                                unconnected.Add(tag, zdo);
+                            }
+                            else
+                            {
+                                connected.Add(zdo);
+                                connected.Add(unconnected[tag]);
+                                unconnected.Remove(tag);
+                            }
+
+                        }
+                    }
+                }
+
+                package.Write(connected.Count);
+                foreach (var connectedPortal in connected)
+                {
+                    package.Write(connectedPortal.m_position);
+                    package.Write("*" + connectedPortal.GetString("tag"));
+                }
+
+                package.Write(unconnected.Count);
+                foreach (var unconnectedPortal in unconnected)
+                {
+                    package.Write(unconnectedPortal.Value.m_position);
+                    package.Write(unconnectedPortal.Value.GetString("tag"));
+                }
+
+                // Send only to single client (new peer) if zPackage is null
+                if (teleporterZPackage == null)
+                {
+                    ZLog.Log("Sending portal information to client (new peer)");
+                    // Send to single client (on new connections only)
+                    ZRoutedRpc.instance.InvokeRoutedRPC(sender, nameof(RPC_VPlusTeleporterSync).Substring(4), new object[] { package });
+                }
+                else
+                {
+                    ZLog.Log("Sending portal information to all clients");
+                    foreach (var peer in ZNet.instance.m_peers)
+                    {
+                        if (!peer.m_server)
+                        {
+                            // Send to all clients
+                            ZRoutedRpc.instance.InvokeRoutedRPC(peer.m_uid, nameof(RPC_VPlusTeleporterSync).Substring(4), new object[] { package });
+                        }
+                    }
+                }
+            }
+
+            // CLIENT SIDE
+            else
+            {
+                if (teleporterZPackage != null && teleporterZPackage.Size() > 0 && sender == ZRoutedRpc.instance.GetServerPeerID())
+                {
+                    int numConnectedPortals = teleporterZPackage.ReadInt();
+
+                    Dictionary<Vector3, string> checkList = new Dictionary<Vector3, string>();
+
+                    // prevent MT crashing
+                    lock (addedPins)
+                    {
+                        while (numConnectedPortals > 0)
+                        {
+                            Vector3 portalPosition = teleporterZPackage.ReadVector3();
+                            string portalName = teleporterZPackage.ReadString();
+
+                            checkList.Add(portalPosition, portalName);
+
+                            // Was pin already added?
+                            Minimap.PinData foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
+                            if (foundPin != null)
+                            {
+                                // Did the pin's name change?
+                                if (foundPin.m_name != portalName)
+                                {
+                                    // Remove pin at location and readd with new name
+                                    Minimap.instance.RemovePin(foundPin);
+                                    addedPins.Remove(foundPin);
+                                    addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                                }
+                            }
+                            else
+                            {
+                                // Add new pin
+                                addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                            }
+
+                            numConnectedPortals--;
+                        }
+
+                        int numUnconnectedPortals = teleporterZPackage.ReadInt();
+
+                        while (numUnconnectedPortals > 0)
+                        {
+                            Vector3 portalPosition = teleporterZPackage.ReadVector3();
+                            string portalName = teleporterZPackage.ReadString();
+
+                            checkList.Add(portalPosition, portalName);
+
+                            // Was pin already added?
+                            Minimap.PinData foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
+                            if (foundPin != null)
+                            {
+                                // Did the pin's name change?
+                                if (foundPin.m_name != portalName)
+                                {
+                                    // Remove pin at location and readd with new name
+                                    addedPins.Remove(foundPin);
+                                    addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                                }
+                            }
+                            else
+                            {
+                                // Add new pin
+                                addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                            }
+
+                            numUnconnectedPortals--;
+                        }
+
+                        // Remove destroyed portals from map
+                        // doesn't really react on portal destruction, only works if after a portal was destroyed, someone set the name on another portal
+                        foreach (var kv in addedPins.ToList())
+                        {
+                            if (checkList.All(x => x.Key != kv.m_pos))
+                            {
+                                addedPins.Remove(kv);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+
+
     // React to setting tag on portal
     // Send special Chatmessage to server
     [HarmonyPatch(typeof(TeleportWorld), "RPC_SetTag", new Type[] { typeof(long), typeof(string) })]
@@ -19,164 +212,91 @@ namespace ValheimPlus
             {
                 return;
             }
+
+            // Force sending ZDO to server
             ZDO temp = __instance.m_nview.GetZDO();
 
             ZDOMan.instance.GetZDO(temp.m_uid);
 
-            foreach (ZDOMan.ZDOPeer peer in ZDOMan.instance.m_peers)
+            ZDOMan.instance.GetPeer(ZRoutedRpc.instance.GetServerPeerID()).ForceSendZDO(temp.m_uid);
+            Task.Factory.StartNew(() =>
             {
-                peer.ForceSendZDO(temp.m_uid);
-            }
-
-            // I used the ChatMessage RPC since this is one of the few calls which are received/processed on the server and can be issued on client
-            ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.Everybody, "ChatMessage", new object[] { Player.m_localPlayer.GetHeadPoint(), 2, "SERVER", "PORTALUPDATE" });
+                // Wait for ZDO to be sent else server won't have accurate information to send back
+                Thread.Sleep(5000);
+                // Send trigger to server
+                ZLog.Log("Sending message to server to trigger delivery of map icons after renaming portal");
+                ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
+                    new object[] { new ZPackage() });
+            });
         }
     }
 
 
-    // Receive special chat message from client
-    // Force sending new LocationIcons to all clients for map update
-    //
-    // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
-    // Prevent further execution, if it is a special message (name == "SERVER", text == "PORTALUPDATE")
-    // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
-    [HarmonyPatch(typeof(Chat), "RPC_ChatMessage", new Type[] { typeof(long), typeof(Vector3), typeof(int), typeof(string), typeof(string) })]
+    // CLIENT SIDE
+    [HarmonyPatch(typeof(Minimap), "SetMapData")]
     public static class SyncTeleporterOnMap2
     {
-        public static bool Prefix(Chat __instance, long sender, string name, string text)
+        public static void Postfix()
         {
-            if (text == "PORTALUPDATE" && name == "SERVER")
-            {
-                if (ZNet.instance.IsServer())
-                {
-                    Task.Factory.StartNew(() =>
-                    {
-                        Thread.Sleep(5000);
-                        foreach (var peer in ZNet.instance.m_peers)
-                        {
-                            if (!peer.m_server)
-                            {
-                                ZoneSystem.instance.SendLocationIcons(peer.m_uid);
-                            }
-                        }
-                    });
-                }
-                return false;
-            }
-
-            return true;
-        }
-    }
-
-    // Hook GetLocationIcons and add all portal locations with prefix "PORTAL"
-    [HarmonyPatch(typeof(ZoneSystem), "GetLocationIcons", new Type[] { typeof(Dictionary<Vector3, string>) })]
-    public static class SyncTeleporterOnMap3
-    {
-        // Only serverside
-        public static void Prefix(ref ZoneSystem __instance, ref Dictionary<Vector3, string> icons)
-        {
-            if (!ZNet.instance.IsServer())
+            if (ZNet.m_isServer)
             {
                 return;
             }
 
-            List<ZDO> connected = new List<ZDO>();
-            Dictionary<string, ZDO> unconnected = new Dictionary<string, ZDO>();
+            ZLog.Log("Sending message to server to trigger delivery of map icons");
+            ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
+                new object[] { new ZPackage() });
 
-            foreach (List<ZDO> zdoarray in ZDOMan.instance.m_objectsBySector)
-            {
-                if (zdoarray != null)
-                {
-                    foreach (ZDO zdo in zdoarray.Where(x => x.m_prefab == -661882940))
-                    {
-                        string tag = zdo.GetString("tag");
-
-                        if (!unconnected.ContainsKey(tag))
-                        {
-                            unconnected.Add(tag, zdo);
-                        }
-                        else
-                        {
-                            connected.Add(zdo);
-                            connected.Add(unconnected[tag]);
-                            unconnected.Remove(tag);
-                        }
-
-                    }
-                }
-            }
-
-            // Add icons for connected portals
-            // prefix connected names with a *
-            foreach (var zdo in connected)
-            {
-                icons[zdo.m_position] = "PORTAL* " + zdo.GetString("tag");
-            }
-
-            // Add icons for unconnected portals
-            // no prefix
-            foreach (var zdo in unconnected.Values)
-            {
-                icons[zdo.m_position] = "PORTAL" + zdo.GetString("tag");
-            }
         }
+    }
 
-        // Holder for our pins
-        private static List<Minimap.PinData> addedPins;
-
-        // only client-side
-        public static void Postfix(ref ZoneSystem __instance, ref Dictionary<Vector3, string> icons)
+    // CLIENT SIDE Set map pins after UpdateLocationPins
+    [HarmonyPatch(typeof(Minimap), "UpdateLocationPins")]
+    public static class SyncTeleporterOnMap3
+    {
+        public static void Postfix()
         {
-            if (!ZNet.instance.IsServer())
+            if (ZNet.m_isServer)
             {
-                if (addedPins == null)
+                return;
+            }
+
+            List<Minimap.PinData> copy;
+
+            lock (VPlusTeleporterSync.addedPins)
+            {
+                copy = VPlusTeleporterSync.addedPins.ToList();
+            }
+
+            foreach (var pin in copy)
+            {
+                Minimap.PinData foundPin = Minimap.instance.m_pins.FirstOrDefault(x => x.m_pos == pin.m_pos);
+
+                if (foundPin == null)
                 {
-                    addedPins = new List<Minimap.PinData>();
+                    // Pin not on map, add
+                    Minimap.instance.AddPin(pin.m_pos, pin.m_type, pin.m_name, pin.m_save, pin.m_checked);
+                }
+                else if (foundPin.m_name != pin.m_name)
+                {
+                    // Pin name change, remove and add new
+                    Minimap.instance.RemovePin(foundPin);
+                    Minimap.instance.AddPin(pin.m_pos, pin.m_type, pin.m_name, pin.m_save, pin.m_checked);
+                }
+            }
+
+
+            foreach (var pin in Minimap.instance.m_pins.Where(x => !x.m_save).ToList())
+            {
+                // Do nothing if it is a location pin
+                if (Minimap.instance.m_locationPins.Values.Any(x => x.m_pos == pin.m_pos))
+                {
+                    continue;
                 }
 
-                Dictionary<Vector3, string> checkList = new Dictionary<Vector3, string>();
-                
-                // Add all portal 'icons' to our checklist
-                foreach (var key in icons.Keys.ToArray())
+                if (copy.All(x => x.m_pos != pin.m_pos))
                 {
-                    if (icons[key].StartsWith("PORTAL"))
-                    {
-                        checkList.Add(key, icons[key].Substring(6));
-                        icons.Remove(key);
-                    }
-                }
-
-                foreach (var kv in checkList)
-                {
-                    // Was pin already added?
-                    Minimap.PinData foundPin = addedPins.FirstOrDefault(x => x.m_pos == kv.Key);
-                    if (foundPin != null)
-                    {
-                        // Did the pin's name change?
-                        if (foundPin.m_name != kv.Value)
-                        {
-                            // Remove pin at location and readd with new name
-                            Minimap.instance.RemovePin(foundPin);
-                            addedPins.Remove(foundPin);
-                            addedPins.Add(Minimap.instance.AddPin(kv.Key, Minimap.PinType.Icon4, kv.Value, false, false));
-                        }
-                    }
-                    else
-                    {
-                        // Add new pin
-                        addedPins.Add(Minimap.instance.AddPin(kv.Key, Minimap.PinType.Icon4, kv.Value, false, false));
-                    }
-                }
-
-                // Remove destroyed portals from map
-                // doesn't really react on portal destruction, only works if after a portal was destroyed, someone set the name on another portal
-                foreach (var kv in addedPins.ToList())
-                {
-                    if (checkList.All(x => x.Key != kv.m_pos))
-                    {
-                        Minimap.instance.RemovePin(kv);
-                        addedPins.Remove(kv);
-                    }
+                    Minimap.instance.RemovePin(pin);
                 }
             }
         }

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -379,6 +379,7 @@
     <Compile Include="SharedMapSystem.cs" />
     <Compile Include="Smelter.cs" />
     <Compile Include="PlayerStats.cs" />
+    <Compile Include="TeleporterOnMap.cs" />
     <Compile Include="UI\VPlusMainMenu.cs" />
     <Compile Include="Utility\EmbeddedAsset.cs" />
     <Compile Include="Version.cs" />


### PR DESCRIPTION
Show all portals on map with their respective names (connected portals prefixed with a *)
Sync on login or rename (with 5sec delay to account for ZDOS transfer)