### PR TITLE
Feature: iniseparation and revamp

### DIFF
--- a/ValheimPlus/AdvancedEditingMode.cs
+++ b/ValheimPlus/AdvancedEditingMode.cs
@@ -34,11 +34,12 @@ namespace ValheimPlus
                 }
                 else
                 {
+                    /*  Disabled for now, the max zoom default values are not correct
                     // Set default values first
                     __instance.m_maxDistance = Configuration.Current.Camera.GetDefault<float>(nameof(Configuration.Current.Camera.cameraMaximumZoomDistance));
                     __instance.m_maxDistanceBoat=Configuration.Current.Camera.GetDefault<float>(nameof(Configuration.Current.Camera.cameraBoatMaximumZoomDistance));
                     __instance.m_fov = Configuration.Current.Camera.GetDefault<float>(nameof(Configuration.Current.Camera.cameraFOV));
-
+                    */
                     if(Configuration.Current.Camera.IsEnabled)
                     {
                         if(Configuration.Current.Camera.cameraMaximumZoomDistance >= 1 && Configuration.Current.Camera.cameraMaximumZoomDistance <= 100)

--- a/ValheimPlus/AdvancedEditingMode.cs
+++ b/ValheimPlus/AdvancedEditingMode.cs
@@ -34,6 +34,11 @@ namespace ValheimPlus
                 }
                 else
                 {
+                    // Set default values first
+                    __instance.m_maxDistance = Configuration.Current.Camera.GetDefault<float>(nameof(Configuration.Current.Camera.cameraMaximumZoomDistance));
+                    __instance.m_maxDistanceBoat=Configuration.Current.Camera.GetDefault<float>(nameof(Configuration.Current.Camera.cameraBoatMaximumZoomDistance));
+                    __instance.m_fov = Configuration.Current.Camera.GetDefault<float>(nameof(Configuration.Current.Camera.cameraFOV));
+
                     if(Configuration.Current.Camera.IsEnabled)
                     {
                         if(Configuration.Current.Camera.cameraMaximumZoomDistance >= 1 && Configuration.Current.Camera.cameraMaximumZoomDistance <= 100)

--- a/ValheimPlus/Beehive.cs
+++ b/ValheimPlus/Beehive.cs
@@ -10,7 +10,7 @@ namespace ValheimPlus
         {
             // Set default values first
             ___m_maxHoney = Configuration.Current.Beehive.GetDefault<int>(nameof(Configuration.Current.Beehive.maximumHoneyPerBeehive));
-            ___m_secPerUnit = Configuration.Current.Beehive.GetDefault<int>(nameof(Configuration.Current.Beehive.honeyProductionSpeed));
+            ___m_secPerUnit = Configuration.Current.Beehive.GetDefault<float>(nameof(Configuration.Current.Beehive.honeyProductionSpeed));
 
             if (Configuration.Current.Beehive.IsEnabled)
             {

--- a/ValheimPlus/Beehive.cs
+++ b/ValheimPlus/Beehive.cs
@@ -8,6 +8,10 @@ namespace ValheimPlus
     {
         private static bool Prefix(ref float ___m_secPerUnit, ref int ___m_maxHoney)
         {
+            // Set default values first
+            ___m_maxHoney = Configuration.Current.Beehive.GetDefault<int>(nameof(Configuration.Current.Beehive.maximumHoneyPerBeehive));
+            ___m_secPerUnit = Configuration.Current.Beehive.GetDefault<int>(nameof(Configuration.Current.Beehive.honeyProductionSpeed));
+
             if (Configuration.Current.Beehive.IsEnabled)
             {
                 ___m_secPerUnit = Configuration.Current.Beehive.honeyProductionSpeed;

--- a/ValheimPlus/Configurations/ActivationTime.cs
+++ b/ValheimPlus/Configurations/ActivationTime.cs
@@ -1,0 +1,13 @@
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations
+{
+    public enum ActivationTime
+    {
+        Immediately,
+        AfterAwake,
+        AfterRelog,
+        AfterRestart,
+        AfterRestartServer
+    }
+}

--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -16,6 +16,25 @@ namespace ValheimPlus.Configurations
     public abstract class BaseConfig
     {
         public static readonly Dictionary<Type, List<PropertyInfo>> propertyCache = new Dictionary<Type, List<PropertyInfo>>();
+
+        internal static IEnumerable<PropertyInfo> GetProps<T>()
+        {
+            return GetProps(typeof(T));
+        }
+
+        internal static IEnumerable<PropertyInfo> GetProps(Type t)
+        {
+            if (!propertyCache.ContainsKey(t))
+            {
+                propertyCache.Add(t,t.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy).ToList());
+            }
+
+            foreach (var property in propertyCache[t])
+            {
+                yield return property;
+            }
+        }
+
     }
 
     public abstract class BaseConfig<T> : BaseConfig, IConfig where T : IConfig, new()
@@ -58,19 +77,6 @@ namespace ValheimPlus.Configurations
         }
 
 
-        private static IEnumerable<PropertyInfo> GetProps<T>()
-        {
-            if (!propertyCache.ContainsKey(typeof(T)))
-            {
-                // If not cached already, cache it
-                propertyCache.Add(typeof(T), typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy).ToList());
-            }
-
-            foreach (var property in propertyCache[typeof(T)])
-            {
-                yield return property;
-            }
-        }
 
         public void LoadIniData(KeyDataCollection data)
         {

--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -35,15 +35,16 @@ namespace ValheimPlus.Configurations
         {
             var n = new T();
 
-
             Debug.Log($"Loading config section {section}");
+            if (data[section] != null)
+            {
+                n.LoadIniData(data[section]);
+            }
             if (data[section] == null || data[section][nameof(IsEnabled)] == null || !data[section].GetBool(nameof(IsEnabled)))
             {
+                n.IsEnabled = false;
                 Debug.Log(" Section not enabled");
-                return n;
             }
-
-            n.LoadIniData(data[section]);
 
             return n;
         }

--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -13,10 +13,25 @@ namespace ValheimPlus.Configurations
 
     public abstract class BaseConfig<T> : IConfig where T : IConfig, new()
     {
-        public bool IsEnabled { get; set; } = false;
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set
+            {
+                if (value != _isEnabled)
+                {
+                    SectionStatusChangedEvent?.Invoke(this, new SectionStatusChangeEventArgs(value));
+                }
+                _isEnabled = value;
+            }
+        }
+
+        public EventHandler<SectionStatusChangeEventArgs> SectionStatusChangedEvent;
+
         public virtual bool NeedsServerSync { get; set; } = false;
 
         public static IniData iniUpdated = null;
+        private bool _isEnabled = false;
 
         public static T LoadIni(IniData data, string section)
         {
@@ -89,7 +104,7 @@ namespace ValheimPlus.Configurations
 
     }
 
-    public abstract class ServerSyncConfig<T> : BaseConfig<T>, ISyncableSection where T : IConfig,  new() 
+    public abstract class ServerSyncConfig<T> : BaseConfig<T>, ISyncableSection where T : IConfig, new()
     {
         public override bool NeedsServerSync { get; set; } = true;
     }

--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -13,19 +13,6 @@ namespace ValheimPlus.Configurations
 
     public abstract class BaseConfig<T> : IConfig where T : IConfig, new()
     {
-        public string ServerSerializeSection()
-        {
-            if (!IsEnabled || !NeedsServerSync) return "";
-
-            var r = "";
-
-            foreach (var prop in typeof(T).GetProperties())
-            {
-                r += $"{prop.Name}={prop.GetValue(this, null)}|";
-            }
-            return r;
-        }
-
         public bool IsEnabled { get; set; } = false;
         public virtual bool NeedsServerSync { get; set; } = false;
 

--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using IniParser.Model;
 using System.Linq;
 using UnityEngine;
@@ -7,11 +8,11 @@ namespace ValheimPlus.Configurations
     public interface IConfig
     {
         void LoadIniData(KeyDataCollection data);
+        bool IsEnabled { get; set; }
     }
 
     public abstract class BaseConfig<T> : IConfig where T : IConfig, new()
     {
-
         public string ServerSerializeSection()
         {
             if (!IsEnabled || !NeedsServerSync) return "";
@@ -25,8 +26,8 @@ namespace ValheimPlus.Configurations
             return r;
         }
 
-        public bool IsEnabled = false;
-        public virtual bool NeedsServerSync { get; set;} = false;
+        public bool IsEnabled { get; set; } = false;
+        public virtual bool NeedsServerSync { get; set; } = false;
 
         public static IniData iniUpdated = null;
 
@@ -34,9 +35,9 @@ namespace ValheimPlus.Configurations
         {
             var n = new T();
 
-            
+
             Debug.Log($"Loading config section {section}");
-            if (data[section] == null || data[section]["enabled"] == null || !data[section].GetBool("enabled"))
+            if (data[section] == null || data[section][nameof(IsEnabled)] == null || !data[section].GetBool(nameof(IsEnabled)))
             {
                 Debug.Log(" Section not enabled");
                 return n;
@@ -61,7 +62,8 @@ namespace ValheimPlus.Configurations
                     keyName = char.ToLower(keyName[0]) + keyName.Substring(1);
                 }
 
-                if (!data.ContainsKey(keyName)) {
+                if (!data.ContainsKey(keyName))
+                {
                     Debug.Log($" Key {keyName} not defined, using default value");
                     continue;
                 }
@@ -99,7 +101,8 @@ namespace ValheimPlus.Configurations
 
     }
 
-    public abstract class ServerSyncConfig<T>: BaseConfig<T> where T : IConfig, new() {
-        public override bool NeedsServerSync { get; set;} = true;
+    public abstract class ServerSyncConfig<T> : BaseConfig<T>, ISyncableSection where T : IConfig,  new() 
+    {
+        public override bool NeedsServerSync { get; set; } = true;
     }
 }

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -1,11 +1,18 @@
-﻿using ValheimPlus.Configurations.Sections;
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using BepInEx;
+using IniParser;
+using IniParser.Model;
+using UnityEngine;
+using ValheimPlus.Configurations.Sections;
 
 namespace ValheimPlus.Configurations
 {
-    public class Configuration
+    public partial class Configuration
     {
-        public static Configuration Current { get; set; }
-
         public AdvancedBuildingModeConfiguration AdvancedBuildingMode { get; set; }
         public AdvancedEditingModeConfiguration AdvancedEditingMode { get; set; }
         public BeehiveConfiguration Beehive { get; set; }
@@ -31,5 +38,6 @@ namespace ValheimPlus.Configurations
         public CameraConfiguration Camera { get; set; }
         public GameConfiguration Game { get; set; }
         public VagonConfiguration Wagon { get; set; }
+
     }
 }

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -25,6 +25,7 @@ namespace ValheimPlus.Configurations
         public HotkeyConfiguration Hotkeys { get; set; }
         public KilnConfiguration Kiln { get; set; }
         public MapConfiguration Map { get; set; }
+        public MapServerConfiguration MapServer { get; set; }
         public PlayerConfiguration Player { get; set; }
         public ServerConfiguration Server { get; set; }
         public StaminaConfiguration Stamina { get; set; }

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -38,6 +38,6 @@ namespace ValheimPlus.Configurations
         public CameraConfiguration Camera { get; set; }
         public GameConfiguration Game { get; set; }
         public VagonConfiguration Wagon { get; set; }
-
+        public PlantConfiguration Plant { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/ConfigurationAttribute.cs
+++ b/ValheimPlus/Configurations/ConfigurationAttribute.cs
@@ -1,18 +1,19 @@
-﻿using System;
-using Steamworks;
+﻿// ValheimPlus
+
+using System;
 
 namespace ValheimPlus.Configurations
 {
     [AttributeUsage(AttributeTargets.Property)]
     public class ConfigurationAttribute : Attribute
     {
-        public string Comment { get; set; }
-        public string SinceVersion { get; set; }
-
         public ConfigurationAttribute(string comment, string sinceVersion = "0.8.5")
         {
             Comment = comment;
             SinceVersion = sinceVersion;
         }
+
+        public string Comment { get; set; }
+        public string SinceVersion { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/ConfigurationAttribute.cs
+++ b/ValheimPlus/Configurations/ConfigurationAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Steamworks;
+
+namespace ValheimPlus.Configurations
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ConfigurationAttribute : Attribute
+    {
+        public string Comment { get; set; }
+        public string SinceVersion { get; set; }
+
+        public ConfigurationAttribute(string comment, string sinceVersion = "0.8.5")
+        {
+            Comment = comment;
+            SinceVersion = sinceVersion;
+        }
+    }
+}

--- a/ValheimPlus/Configurations/ConfigurationAttribute.cs
+++ b/ValheimPlus/Configurations/ConfigurationAttribute.cs
@@ -7,13 +7,15 @@ namespace ValheimPlus.Configurations
     [AttributeUsage(AttributeTargets.Property)]
     public class ConfigurationAttribute : Attribute
     {
-        public ConfigurationAttribute(string comment, string sinceVersion = "0.8.5")
+        public ConfigurationAttribute(string comment, ActivationTime activationTime, string sinceVersion = "0.8.5")
         {
             Comment = comment;
             SinceVersion = sinceVersion;
+            ActivationTime = activationTime;
         }
 
         public string Comment { get; set; }
         public string SinceVersion { get; set; }
+        public ActivationTime ActivationTime { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -34,7 +34,11 @@ namespace ValheimPlus.Configurations
             foreach (var property in propertyCache)
             {
                 ZLog.Log($"Initializing configuration section {property.Name}");
-                property.SetValue(this, Activator.CreateInstance(property.PropertyType, true), null);
+                var section = Activator.CreateInstance(property.PropertyType, true);
+                property.SetValue(this, section, null);
+
+                // and finally cache the default values
+                ((BaseConfig) section).CacheDefaults();
             }
         }
 

--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -163,6 +163,10 @@ namespace ValheimPlus.Configurations
 
                 var value = configProperty.GetValue(section, null);
                 string valueAsString = value.ToString();
+                if (value is float)
+                {
+                    valueAsString = ((float) value).ToString(CultureInfo.InvariantCulture.NumberFormat);
+                }
 
                 // Special case 'IsEnabled'
                 if (configProperty.Name == "IsEnabled")

--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -6,103 +6,281 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using IniParser.Parser;
 using UnityEngine;
 
 namespace ValheimPlus.Configurations
 {
-    public class ConfigurationExtra
+    // Configuration implementation part
+    public partial class Configuration
     {
-        public static string GetServerHashFor(Configuration config) {
-            var serialized = "";
-            foreach (var prop in typeof(Configuration).GetProperties())
+        public static string ConfigIniPath = Path.GetDirectoryName(Paths.BepInExConfigPath);
+
+        // Loaded configuration
+        public static Configuration Current { get; private set; }
+
+        /// <summary>
+        /// Load configuration from it's ini files
+        /// </summary>
+        /// <param name="isClient"></param>
+        /// <returns></returns>
+        public static bool LoadConfiguration(bool isClient = false)
+        {
+            bool errorWhileLoadingIni = false;
+            Current = new Configuration();
+            try
             {
-                var keyName = prop.Name;
-                var method = prop.PropertyType.GetMethod("ServerSerializeSection", BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
-                
-                if (method != null)
+                foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
-                    var instance = prop.GetValue(config, null);
-                    string result = (string)method.Invoke(instance, new object[] { });
-                    serialized += result;
+                    string iniPath = Path.Combine(ConfigIniPath, property.Name + ".ini");
+                
+                    bool needsSync = typeof(ISyncableSection).IsAssignableFrom(property.PropertyType);
+
+                    if ((isClient && !needsSync) || (!isClient && needsSync))
+                    {
+                        if (File.Exists(iniPath))
+                        {
+                            errorWhileLoadingIni |= !LoadFromIni(Current, property, iniPath);
+                        }
+                        else
+                        {
+                           Debug.Log($"Saving missing default config for {property.Name}");
+                            Current.SaveConfiguration(property, isClient);
+                            errorWhileLoadingIni = true;
+                        }
+                    }
+                }
+
+                // If there were errors while loading the ini files, try to write missing ones
+                if (errorWhileLoadingIni)
+                {
+                    Debug.Log("Trying to write missing ini files");
+                    Configuration.Current.SaveConfiguration();
                 }
             }
-            return Settings.CreateMD5(serialized);
+            catch (Exception e)
+            {
+                Debug.Log(e.Message);
+                Debug.Log(e.StackTrace);
+            }
+
+            return !errorWhileLoadingIni;
         }
 
-        public static string ConfigIniPath = Path.GetDirectoryName(Paths.BepInExConfigPath) + Path.DirectorySeparatorChar + "valheim_plus.cfg";
+        public Configuration()
+        {
+            // Create all configuration entries with default values
+            foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                property.SetValue(this, Activator.CreateInstance(property.PropertyType, true), null);
+            }
+        }
 
-        public static bool LoadSettings()
+        public string GetSyncableSections()
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                sb.AppendLine(GenerateSection(property, property.GetValue(this, null), false));
+            }
+
+            return sb.ToString();
+        }
+
+
+        private void SaveConfiguration()
+        {
+            bool isClient = true;
+            isClient = ServerCtrl.m_instance == null;
+            foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance).ToList())
+            {
+                SaveConfiguration(property, isClient);
+            }
+        }
+
+        private void SaveConfiguration(PropertyInfo property, bool isClient)
+        {
+            string configName = property.Name + ".ini";
+
+            Type sectionType = property.PropertyType;
+
+            // For clients only save client values, for servers only server values
+            object section = property.GetValue(Configuration.Current, null);
+            bool needsSync = section is ISyncableSection;
+
+            if ((isClient && !needsSync) || (!isClient && needsSync))
+            {
+                using (TextWriter tw = new StreamWriter(Path.Combine(ConfigIniPath, configName)))
+                {
+                    tw.Write(GenerateSection(property, section, true));
+                }
+            }
+        }
+
+        private static string GenerateSection(PropertyInfo property, object section, bool withComments = false)
+        {
+            StringBuilder sb = new StringBuilder();
+            Type sectionType = property.PropertyType;
+            var sectionAttribute = sectionType.GetCustomAttributes(false).OfType<ConfigurationSectionAttribute>().FirstOrDefault();
+
+            if (sectionAttribute != null && withComments)
+            {
+                sb.AppendLine(sectionAttribute.Comment.ToIniComment());
+                sb.AppendLine("; V" + sectionAttribute.SinceVersion);
+            }
+
+            sb.AppendLine($"[{property.Name}]");
+
+            // IsEnabled first
+
+            var enabledProperty = typeof(IConfig).GetProperty("IsEnabled", BindingFlags.Public | BindingFlags.Instance);
+            var enabledValue = enabledProperty.GetValue(section, null);
+            string enabledAsString = enabledValue.ToString();
+
+            if (withComments)
+            {
+                sb.AppendLine("; Change false to true to enable this section");
+            }
+            sb.AppendLine($"{enabledProperty.Name}={enabledAsString}");
+
+            if (withComments)
+            {
+                sb.AppendLine();
+            }
+
+            foreach (var configProperty in sectionType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy).ToList())
+            {
+                // Dont need to write NeedsServerSync
+
+                if (configProperty.Name == "NeedsServerSync")
+                {
+                    continue;
+                }
+
+                var value = configProperty.GetValue(section, null);
+                string valueAsString = value.ToString();
+
+                // Special case 'IsEnabled'
+                if (configProperty.Name == "IsEnabled")
+                {
+                    continue;
+                }
+
+                ConfigurationAttribute ca = configProperty.GetCustomAttributes(false).OfType<ConfigurationAttribute>().FirstOrDefault();
+
+                if (ca != null && withComments)
+                {
+                    sb.Append(ca.Comment.ToIniComment());
+                    sb.AppendLine($"; V{ca.SinceVersion}");
+                }
+
+                sb.AppendLine($"{configProperty.Name}={valueAsString}");
+
+                if (withComments)
+                {
+                    sb.AppendLine();
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        public static bool LoadFromIni(Configuration config, PropertyInfo property, string filename)
         {
             try
             {
-                if (File.Exists(ConfigIniPath))
-                    Configuration.Current = LoadFromIni(ConfigIniPath);
-                else
+                var parser = new FileIniDataParser();
+
+                IniData configdata = new IniData();
+                if (File.Exists(filename))
                 {
-                    Debug.LogError("Error: Configuration not found. Plugin not loaded.");
-                    return false;
+                    configdata = parser.ReadFile(filename);
                 }
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError($"Could not load config file: {ex}");
-                return false;
-            }
-            return true;
-        }
 
-        public static Configuration LoadFromIni(string filename)
-        {
-            var parser = new FileIniDataParser();
-            IniData configdata = parser.ReadFile(filename);
-
-
-            var conf = new Configuration();
-            foreach (var prop in typeof(Configuration).GetProperties())
-            {
-                var keyName = prop.Name;
-                var method = prop.PropertyType.GetMethod("LoadIni", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+                var keyName = property.Name;
+                var method = property.PropertyType.GetMethod("LoadIni", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
 
                 if (method != null)
                 {
                     var result = method.Invoke(null, new object[] { configdata, keyName });
-                    prop.SetValue(conf, result, null);
+                    property.SetValue(config, result, null);
                 }
             }
-            return conf;
+            catch (Exception e)
+            {
+                Debug.Log($"Error loading ini file {filename}");
+                Debug.Log(e.Message);
+                return false;
+            }
+
+            return true;
         }
 
-        public static Configuration LoadFromIni(Stream iniStream)
+        /// <summary>
+        /// Only set values which should be synced to current configuration
+        /// </summary>
+        /// <param name="receivedConfig"></param>
+        public static void SetSyncableValues(Configuration receivedConfig)
         {
-            using (StreamReader iniReader = new StreamReader(iniStream))
+            foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(x => typeof(ISyncableSection).IsAssignableFrom(x.PropertyType)))
             {
-                var parser = new FileIniDataParser();
-                IniData configdata = parser.ReadData(iniReader);
+                property.SetValue(Current, property.GetValue(receivedConfig, null), null);
+            }
+        }
 
-                var conf = new Configuration();
-                foreach (var prop in typeof(Configuration).GetProperties())
+        public static void LoadFromIniString(Configuration receivedConfig, string inputString)
+        {
+            try
+            {
+                var parser = new IniDataParser();
+                var ini = parser.Parse(inputString);
+
+                foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
-                    var keyName = prop.Name;
-                    var method = prop.PropertyType.GetMethod("LoadIni",
-                        BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-
-                    if (method != null)
+                    if (ini.Sections.ContainsSection(property.Name))
                     {
-                        var result = method.Invoke(null, new object[] {configdata, keyName});
-                        prop.SetValue(conf, result, null);
+                        var result = property.PropertyType.GetMethod("LoadIni", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?
+                            .Invoke(null, new object[] { ini, property.Name });
+                        if (result == null)
+                        {
+                            throw new Exception($"LoadIni method not found on Type {property.PropertyType.Name}");
+                        }
+                        property.SetValue(receivedConfig, result, null);
                     }
                 }
-
-                return conf;
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"Error {e.Message} occured while parsing synced config");
+                
+                Debug.LogError($"while parsing {Environment.NewLine}{inputString}");
             }
         }
+
     }
+
+    public static class StringExtensions
+    {
+        public static string ToIniComment(this string comment)
+        {
+            StringBuilder sb = new StringBuilder();
+            foreach (string line in comment.Split('\n'))
+            {
+                sb.AppendLine("; " + line);
+            }
+
+            return sb.ToString();
+        }
+    }
+
 
     public static class IniDataExtensions
     {
         public static float GetFloat(this KeyDataCollection data, string key, float defaultVal)
         {
-            if (float.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result)) { 
+            if (float.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result))
+            {
                 return result;
             }
             Debug.LogWarning($" [Float] Could not read {key}, using default value of {defaultVal}");
@@ -115,7 +293,8 @@ namespace ValheimPlus.Configurations
         }
         public static int GetInt(this KeyDataCollection data, string key, int defaultVal)
         {
-            if (int.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result)) { 
+            if (int.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result))
+            {
                 return result;
             }
             Debug.LogWarning($" [Int] Could not read {key}, using default value of {defaultVal}");
@@ -124,7 +303,8 @@ namespace ValheimPlus.Configurations
 
         public static KeyCode GetKeyCode(this KeyDataCollection data, string key, KeyCode defaultVal)
         {
-            if (System.Enum.TryParse<KeyCode>(data[key], out var result)) {
+            if (System.Enum.TryParse<KeyCode>(data[key], out var result))
+            {
                 return result;
             }
             Debug.LogWarning($" [KeyCode] Could not read {key}, using default value of {defaultVal}");

--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -33,6 +33,7 @@ namespace ValheimPlus.Configurations
             // Create all configuration entries with default values
             foreach (var property in propertyCache)
             {
+                ZLog.Log($"Initializing configuration section {property.Name}");
                 property.SetValue(this, Activator.CreateInstance(property.PropertyType, true), null);
             }
         }
@@ -137,7 +138,7 @@ namespace ValheimPlus.Configurations
             var section = property.GetValue(Current, null);
             var needsSync = section is ISyncableSection;
 
-            if (isClient && !needsSync || !isClient && needsSync)
+            if (isClient != needsSync)
             {
                 using (TextWriter tw = new StreamWriter(Path.Combine(ConfigIniPath, configName)))
                 {
@@ -185,7 +186,7 @@ namespace ValheimPlus.Configurations
                 sb.AppendLine();
             }
 
-            foreach (var configProperty in BaseConfig.propertyCache[sectionType])
+            foreach (var configProperty in BaseConfig.GetProps(sectionType))
             {
                 var value = configProperty.GetValue(section, null);
                 var valueAsString = value.ToString();

--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -17,7 +17,7 @@ namespace ValheimPlus.Configurations
     // Configuration implementation part
     public partial class Configuration
     {
-        public static string ConfigIniPath = Path.GetDirectoryName(Paths.BepInExConfigPath);
+        public static string ConfigIniPath = Path.Combine(Path.GetDirectoryName(Paths.BepInExConfigPath), "ValheimPlus");
 
         public Configuration()
         {
@@ -43,6 +43,11 @@ namespace ValheimPlus.Configurations
             var sb = new StringBuilder();
             try
             {
+                if (!Directory.Exists(ConfigIniPath))
+                {
+                    Directory.CreateDirectory(ConfigIniPath);
+                }
+
                 foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
                     var iniPath = Path.Combine(ConfigIniPath, property.Name + ".ini");

--- a/ValheimPlus/Configurations/ConfigurationHooks.cs
+++ b/ValheimPlus/Configurations/ConfigurationHooks.cs
@@ -18,11 +18,10 @@ namespace ValheimPlus.Configurations
     [HarmonyPatch(typeof(ZNet), "OnDestroy")]
     public static class ConfigurationHooks2
     {
-        private static void Prefix(ref ZNet __instance)
+        private static void Prefix()
         {
             ZLog.Log("Saving local configuration");
             Configuration.Current.SaveConfiguration();
         }
     }
-
 }

--- a/ValheimPlus/Configurations/ConfigurationHooks.cs
+++ b/ValheimPlus/Configurations/ConfigurationHooks.cs
@@ -14,4 +14,15 @@ namespace ValheimPlus.Configurations
             Configuration.Current.SaveConfiguration();
         }
     }
+
+    [HarmonyPatch(typeof(ZNet), "OnDestroy")]
+    public static class ConfigurationHooks2
+    {
+        private static void Prefix(ref ZNet __instance)
+        {
+            ZLog.Log("Saving local configuration");
+            Configuration.Current.SaveConfiguration();
+        }
+    }
+
 }

--- a/ValheimPlus/Configurations/ConfigurationHooks.cs
+++ b/ValheimPlus/Configurations/ConfigurationHooks.cs
@@ -1,0 +1,17 @@
+﻿// ValheimPlus
+
+using HarmonyLib;
+
+namespace ValheimPlus.Configurations
+{
+    [HarmonyPatch(typeof(ZNet), "RPC_Save")]
+    public static class ConfigurationHooks
+    {
+        public static void Postfix()
+        {
+            // Just save configuration after a save command is issued
+            // Server side only
+            Configuration.Current.SaveConfiguration();
+        }
+    }
+}

--- a/ValheimPlus/Configurations/ConfigurationSectionAttribute.cs
+++ b/ValheimPlus/Configurations/ConfigurationSectionAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace ValheimPlus.Configurations
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ConfigurationSectionAttribute : Attribute
+    {
+        public string Comment { get; set; }
+        public string SinceVersion { get; set; }
+
+        public ConfigurationSectionAttribute(string comment, string sinceVersion = "0.9.0")
+        {
+            Comment = comment;
+            SinceVersion = sinceVersion;
+        }
+    }
+}

--- a/ValheimPlus/Configurations/ISyncableSection.cs
+++ b/ValheimPlus/Configurations/ISyncableSection.cs
@@ -1,0 +1,7 @@
+﻿namespace ValheimPlus.Configurations
+{
+    // Dummy interface to identify syncable configuration options
+    public interface ISyncableSection
+    {
+    }
+}

--- a/ValheimPlus/Configurations/SectionStatusChangeEventArgs.cs
+++ b/ValheimPlus/Configurations/SectionStatusChangeEventArgs.cs
@@ -1,0 +1,16 @@
+﻿// ValheimPlus
+
+using System;
+
+namespace ValheimPlus.Configurations
+{
+    public class SectionStatusChangeEventArgs : EventArgs
+    {
+        public bool Enabled { get; set; }
+
+        public SectionStatusChangeEventArgs(bool enabled)
+        {
+            Enabled = enabled;
+        }
+    }
+}

--- a/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
@@ -9,10 +9,10 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("https://docs.unity3d.com/ScriptReference/KeyCode.html <- a list of keycodes")]
     public class AdvancedBuildingModeConfiguration : BaseConfig<AdvancedBuildingModeConfiguration>
     {
-        [Configuration("Enter the advanced building mode with this key when building")]
+        [Configuration("Enter the advanced building mode with this key when building", ActivationTime.Immediately)]
         public KeyCode enterAdvancedBuildingMode { get; set; } = KeyCode.F1;
 
-        [Configuration("Exit the advanced building mode with this key when building")]
+        [Configuration("Exit the advanced building mode with this key when building", ActivationTime.Immediately)]
         public KeyCode exitAdvancedBuildingMode { get; set; } = KeyCode.F3;
     }
 }

--- a/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
@@ -1,10 +1,18 @@
-﻿using UnityEngine;
+﻿// ValheimPlus
+
+using System;
+using UnityEngine;
 
 namespace ValheimPlus.Configurations.Sections
 {
+    [Serializable]
+    [ConfigurationSection("https://docs.unity3d.com/ScriptReference/KeyCode.html <- a list of keycodes")]
     public class AdvancedBuildingModeConfiguration : BaseConfig<AdvancedBuildingModeConfiguration>
     {
+        [Configuration("Enter the advanced building mode with this key when building")]
         public KeyCode enterAdvancedBuildingMode { get; set; } = KeyCode.F1;
+
+        [Configuration("Exit the advanced building mode with this key when building")]
         public KeyCode exitAdvancedBuildingMode { get; set; } = KeyCode.F3;
     }
 }

--- a/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
@@ -7,16 +7,16 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("https://docs.unity3d.com/ScriptReference/KeyCode.html <- a list of keycodes")]
     public class AdvancedEditingModeConfiguration : BaseConfig<AdvancedEditingModeConfiguration>
     {
-        [Configuration("Enter the advanced editing mode with this key")]
+        [Configuration("Enter the advanced editing mode with this key", ActivationTime.Immediately)]
         public KeyCode enterAdvancedEditingMode { get; internal set; } = KeyCode.Keypad0;
 
-        [Configuration("Reset the object to its original position and rotation")]
+        [Configuration("Reset the object to its original position and rotation", ActivationTime.Immediately)]
         public KeyCode resetAdvancedEditingMode { get; internal set; } = KeyCode.F7;
 
-        [Configuration("Exit the advanced editing mode with this key and reset the object")]
+        [Configuration("Exit the advanced editing mode with this key and reset the object", ActivationTime.Immediately)]
         public KeyCode abortAndExitAdvancedEditingMode { get; internal set; } = KeyCode.F8;
 
-        [Configuration("Confirm the placement of the object and place it")]
+        [Configuration("Confirm the placement of the object and place it", ActivationTime.Immediately)]
         public KeyCode confirmPlacementOfAdvancedEditingMode { get; internal set; } = KeyCode.KeypadEnter;
     }
 }

--- a/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
@@ -1,16 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// ValheimPlus
+
 using UnityEngine;
 
 namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("https://docs.unity3d.com/ScriptReference/KeyCode.html <- a list of keycodes")]
     public class AdvancedEditingModeConfiguration : BaseConfig<AdvancedEditingModeConfiguration>
     {
+        [Configuration("Enter the advanced editing mode with this key")]
         public KeyCode enterAdvancedEditingMode { get; internal set; } = KeyCode.Keypad0;
+
+        [Configuration("Reset the object to its original position and rotation")]
         public KeyCode resetAdvancedEditingMode { get; internal set; } = KeyCode.F7;
-        public KeyCode abortAndExitAdvancedEditingMode { get; internal set; } =  KeyCode.F8;
+
+        [Configuration("Exit the advanced editing mode with this key and reset the object")]
+        public KeyCode abortAndExitAdvancedEditingMode { get; internal set; } = KeyCode.F8;
+
+        [Configuration("Confirm the placement of the object and place it")]
         public KeyCode confirmPlacementOfAdvancedEditingMode { get; internal set; } = KeyCode.KeypadEnter;
     }
 }

--- a/ValheimPlus/Configurations/Sections/BeehiveConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BeehiveConfiguration.cs
@@ -4,10 +4,13 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class BeehiveConfiguration : ServerSyncConfig<BeehiveConfiguration>
     {
-        [Configuration("configure the speed at which the bees produce honey in seconds, 1200 seconds are 24 ingame hours")]
+        // Values will be set, but effective only after they get recreated again by the engine
+        // To force this easily just teleport somewhere and come back
+
+        [Configuration("configure the speed at which the bees produce honey in seconds, 1200 seconds are 24 ingame hours", ActivationTime.Immediately)]
         public float honeyProductionSpeed { get; set; } = 1200;
 
-        [Configuration("configure the maximum amount of honey in beehives")]
+        [Configuration("configure the maximum amount of honey in beehives", ActivationTime.Immediately)]
         public int maximumHoneyPerBeehive { get; set; } = 4;
     }
 }

--- a/ValheimPlus/Configurations/Sections/BeehiveConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BeehiveConfiguration.cs
@@ -1,9 +1,13 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
     public class BeehiveConfiguration : ServerSyncConfig<BeehiveConfiguration>
     {
+        [Configuration("configure the speed at which the bees produce honey in seconds, 1200 seconds are 24 ingame hours")]
         public float honeyProductionSpeed { get; set; } = 1200;
+
+        [Configuration("configure the maximum amount of honey in beehives")]
         public int maximumHoneyPerBeehive { get; set; } = 4;
     }
-
 }

--- a/ValheimPlus/Configurations/Sections/BuildingConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BuildingConfiguration.cs
@@ -4,13 +4,13 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class BuildingConfiguration : ServerSyncConfig<BuildingConfiguration>
     {
-        [Configuration("Remove some of the Invalid placement messages, most notably provides the ability to place objects into other objects")]
+        [Configuration("Remove some of the Invalid placement messages, most notably provides the ability to place objects into other objects", ActivationTime.Immediately)]
         public bool noInvalidPlacementRestriction { get; set; } = false;
 
-        [Configuration("Removes the weather damage from rain")]
+        [Configuration("Removes the weather damage from rain", ActivationTime.Immediately)]
         public bool noWeatherDamage { get; set; } = false;
 
-        [Configuration("The maximum range that you can place build objects at")]
-        public float maximumPlacementDistance { get; internal set; } = 5;
+        [Configuration("The maximum range that you can place build objects at", ActivationTime.Immediately)]
+        public float maximumPlacementDistance { get; set; } = 5;
     }
 }

--- a/ValheimPlus/Configurations/Sections/BuildingConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BuildingConfiguration.cs
@@ -1,11 +1,16 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
     public class BuildingConfiguration : ServerSyncConfig<BuildingConfiguration>
     {
+        [Configuration("Remove some of the Invalid placement messages, most notably provides the ability to place objects into other objects")]
         public bool noInvalidPlacementRestriction { get; set; } = false;
+
+        [Configuration("Removes the weather damage from rain")]
         public bool noWeatherDamage { get; set; } = false;
+
+        [Configuration("The maximum range that you can place build objects at")]
         public float maximumPlacementDistance { get; internal set; } = 5;
-
     }
-
 }

--- a/ValheimPlus/Configurations/Sections/CameraConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/CameraConfiguration.cs
@@ -4,13 +4,13 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class CameraConfiguration : BaseConfig<CameraConfiguration>
     {
-        [Configuration("maximum camera zoom distance")]
-        public float cameraMaximumZoomDistance { get; internal set; } = 1146;
+        [Configuration("maximum camera zoom distance", ActivationTime.Immediately)]
+        public float cameraMaximumZoomDistance { get; set; } = 1146;
 
-        [Configuration("maximum camera zoom distance on boats")]
-        public float cameraBoatMaximumZoomDistance { get; internal set; } = 6;
+        [Configuration("maximum camera zoom distance on boats", ActivationTime.Immediately)]
+        public float cameraBoatMaximumZoomDistance { get; set; } = 6;
 
-        [Configuration("camera FOV (field of view)")]
-        public float cameraFOV { get; internal set; } = 85;
+        [Configuration("camera FOV (field of view)", ActivationTime.Immediately)]
+        public float cameraFOV { get; set; } = 85;
     }
 }

--- a/ValheimPlus/Configurations/Sections/CameraConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/CameraConfiguration.cs
@@ -1,9 +1,16 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
     public class CameraConfiguration : BaseConfig<CameraConfiguration>
     {
+        [Configuration("maximum camera zoom distance")]
         public float cameraMaximumZoomDistance { get; internal set; } = 1146;
+
+        [Configuration("maximum camera zoom distance on boats")]
         public float cameraBoatMaximumZoomDistance { get; internal set; } = 6;
+
+        [Configuration("camera FOV (field of view)")]
         public float cameraFOV { get; internal set; } = 85;
     }
 }

--- a/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
@@ -6,24 +6,24 @@ namespace ValheimPlus.Configurations.Sections
     public class ExperienceConfiguration : ServerSyncConfig<ExperienceConfiguration>
     {
         [Configuration(
-            "Each of these values represent the increase to experience gained by % increased. The value 50 would result in 50% increased experience gained for the respective skill by name.")]
-        public float swords { get; internal set; } = 0;
+            "Each of these values represent the increase to experience gained by % increased. The value 50 would result in 50% increased experience gained for the respective skill by name.", ActivationTime.Immediately)]
+        public float swords { get; set; } = 0;
 
-        public float knives { get; internal set; } = 0;
-        public float clubs { get; internal set; } = 0;
-        public float polearms { get; internal set; } = 0;
-        public float spears { get; internal set; } = 0;
-        public float blocking { get; internal set; } = 0;
-        public float axes { get; internal set; } = 0;
-        public float bows { get; internal set; } = 0;
-        public float fireMagic { get; internal set; } = 0;
-        public float frostMagic { get; internal set; } = 0;
-        public float unarmed { get; internal set; } = 0;
-        public float pickaxes { get; internal set; } = 0;
-        public float woodCutting { get; internal set; } = 0;
-        public float jump { get; internal set; } = 0;
-        public float sneak { get; internal set; } = 0;
-        public float run { get; internal set; } = 0;
-        public float swim { get; internal set; } = 0;
+        public float knives { get; set; } = 0;
+        public float clubs { get; set; } = 0;
+        public float polearms { get; set; } = 0;
+        public float spears { get; set; } = 0;
+        public float blocking { get; set; } = 0;
+        public float axes { get; set; } = 0;
+        public float bows { get; set; } = 0;
+        public float fireMagic { get; set; } = 0;
+        public float frostMagic { get; set; } = 0;
+        public float unarmed { get; set; } = 0;
+        public float pickaxes { get; set; } = 0;
+        public float woodCutting { get; set; } = 0;
+        public float jump { get; set; } = 0;
+        public float sneak { get; set; } = 0;
+        public float run { get; set; } = 0;
+        public float swim { get; set; } = 0;
     }
 }

--- a/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
@@ -1,25 +1,29 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Everything experience-related")]
     public class ExperienceConfiguration : ServerSyncConfig<ExperienceConfiguration>
     {
+        [Configuration(
+            "Each of these values represent the increase to experience gained by % increased. The value 50 would result in 50% increased experience gained for the respective skill by name.")]
         public float swords { get; internal set; } = 0;
-		public float knives { get; internal set; } = 0;
-		public float clubs { get; internal set; } = 0;
-		public float polearms { get; internal set; } = 0;
-		public float spears { get; internal set; } = 0;
-		public float blocking { get; internal set; } = 0;
-		public float axes { get; internal set; } = 0;
-		public float bows { get; internal set; } = 0;
-		public float fireMagic { get; internal set; } = 0;
-		public float frostMagic { get; internal set; } = 0;
-		public float unarmed { get; internal set; } = 0;
-		public float pickaxes { get; internal set; } = 0;
-		public float woodCutting { get; internal set; } = 0;
-		public float jump { get; internal set; } = 0;
-		public float sneak { get; internal set; } = 0;
-		public float run { get; internal set; } = 0;
-		public float swim { get; internal set; } = 0;
 
-	}
-
+        public float knives { get; internal set; } = 0;
+        public float clubs { get; internal set; } = 0;
+        public float polearms { get; internal set; } = 0;
+        public float spears { get; internal set; } = 0;
+        public float blocking { get; internal set; } = 0;
+        public float axes { get; internal set; } = 0;
+        public float bows { get; internal set; } = 0;
+        public float fireMagic { get; internal set; } = 0;
+        public float frostMagic { get; internal set; } = 0;
+        public float unarmed { get; internal set; } = 0;
+        public float pickaxes { get; internal set; } = 0;
+        public float woodCutting { get; internal set; } = 0;
+        public float jump { get; internal set; } = 0;
+        public float sneak { get; internal set; } = 0;
+        public float run { get; internal set; } = 0;
+        public float swim { get; internal set; } = 0;
+    }
 }

--- a/ValheimPlus/Configurations/Sections/FermenterConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FermenterConfiguration.cs
@@ -1,9 +1,14 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Fermenter settings")]
     public class FermenterConfiguration : ServerSyncConfig<FermenterConfiguration>
     {
+        [Configuration("configure the time that the fermenter takes to produce its product, 2400 seconds are 48 ingame hours")]
         public float fermenterDuration { get; set; } = 2400;
+
+        [Configuration("configure the total amount of produced items from a fermenter")]
         public int fermenterItemsProduced { get; set; } = 4;
     }
-
 }

--- a/ValheimPlus/Configurations/Sections/FermenterConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FermenterConfiguration.cs
@@ -5,10 +5,10 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Fermenter settings")]
     public class FermenterConfiguration : ServerSyncConfig<FermenterConfiguration>
     {
-        [Configuration("configure the time that the fermenter takes to produce its product, 2400 seconds are 48 ingame hours")]
+        [Configuration("configure the time that the fermenter takes to produce its product, 2400 seconds are 48 ingame hours", ActivationTime.Immediately)]
         public float fermenterDuration { get; set; } = 2400;
 
-        [Configuration("configure the total amount of produced items from a fermenter")]
+        [Configuration("configure the total amount of produced items from a fermenter", ActivationTime.Immediately)]
         public int fermenterItemsProduced { get; set; } = 4;
     }
 }

--- a/ValheimPlus/Configurations/Sections/FireplaceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FireplaceConfiguration.cs
@@ -5,7 +5,7 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("If changed to enabled all fireplaces do not need to be refilled.")]
     public class FireplaceConfiguration : ServerSyncConfig<FireplaceConfiguration>
     {
-        [Configuration("If you enable this option only placed torches do not need to be refilled.")]
+        [Configuration("If you enable this option only placed torches do not need to be refilled.", ActivationTime.Immediately)]
         public bool onlyTorches { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/Configurations/Sections/FireplaceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FireplaceConfiguration.cs
@@ -1,7 +1,11 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("If changed to enabled all fireplaces do not need to be refilled.")]
     public class FireplaceConfiguration : ServerSyncConfig<FireplaceConfiguration>
     {
+        [Configuration("If you enable this option only placed torches do not need to be refilled.")]
         public bool onlyTorches { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/Configurations/Sections/FoodConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FoodConfiguration.cs
@@ -4,7 +4,7 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class FoodConfiguration : ServerSyncConfig<FoodConfiguration>
     {
-        [Configuration("Increase or reduce the time that food lasts by %. The value 50 would cause food to run out 50% slower.")]
+        [Configuration("Increase or reduce the time that food lasts by %. The value 50 would cause food to run out 50% slower.", ActivationTime.Immediately)]
         public float foodDurationMultiplier { get; set; } = 0;
     }
 }

--- a/ValheimPlus/Configurations/Sections/FoodConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FoodConfiguration.cs
@@ -1,8 +1,10 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
     public class FoodConfiguration : ServerSyncConfig<FoodConfiguration>
     {
+        [Configuration("Increase or reduce the time that food lasts by %. The value 50 would cause food to run out 50% slower.")]
         public float foodDurationMultiplier { get; set; } = 0;
     }
-
 }

--- a/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
@@ -5,20 +5,22 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Furnace settings")]
     public class FurnaceConfiguration : ServerSyncConfig<FurnaceConfiguration>
     {
-        [Configuration("Maximum amount of ore in a furnace")]
+        [Configuration("Maximum amount of ore in a furnace", ActivationTime.AfterRestartServer)]
         public int maximumOre { get; set; } = 10;
 
-        [Configuration("Maximum amount of coal in a furnace")]
+        [Configuration("Maximum amount of coal in a furnace", ActivationTime.AfterRestartServer)]
         public int maximumCoal { get; set; } = 20;
 
-        [Configuration("The total amount of coal used to produce a single smelted ingot.")]
+        [Configuration("The total amount of coal used to produce a single smelted ingot.", ActivationTime.AfterRestartServer)]
         public int coalUsedPerProduct { get; set; } = 2;
 
-        [Configuration("The time it takes for the furnace to produce a single ingot in seconds.")]
+        [Configuration("The time it takes for the furnace to produce a single ingot in seconds.", ActivationTime.AfterRestartServer)]
         public float productionSpeed { get; set; } = 30;
 
-        [Configuration("not used yet")] public bool autoDeposit { get; set; } = false;
+        [Configuration("not used yet", ActivationTime.Immediately)]
+        public bool autoDeposit { get; set; } = false;
 
-        [Configuration("not used yet")] public float autoDepositRange { get; set; } = 10;
+        [Configuration("not used yet", ActivationTime.Immediately)]
+        public float autoDepositRange { get; set; } = 10;
     }
 }

--- a/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
@@ -1,13 +1,24 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Furnace settings")]
     public class FurnaceConfiguration : ServerSyncConfig<FurnaceConfiguration>
     {
+        [Configuration("Maximum amount of ore in a furnace")]
         public int maximumOre { get; set; } = 10;
-        public int maximumCoal { get; set; } = 20;
-        public int coalUsedPerProduct { get; set; } = 2;
-        public float productionSpeed { get; set; } = 30;
-        public bool autoDeposit { get; set; } = false;
-        public float autoDepositRange { get; set; } = 10;
-    }
 
+        [Configuration("Maximum amount of coal in a furnace")]
+        public int maximumCoal { get; set; } = 20;
+
+        [Configuration("The total amount of coal used to produce a single smelted ingot.")]
+        public int coalUsedPerProduct { get; set; } = 2;
+
+        [Configuration("The time it takes for the furnace to produce a single ingot in seconds.")]
+        public float productionSpeed { get; set; } = 30;
+
+        [Configuration("not used yet")] public bool autoDeposit { get; set; } = false;
+
+        [Configuration("not used yet")] public float autoDepositRange { get; set; } = 10;
+    }
 }

--- a/ValheimPlus/Configurations/Sections/GameConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/GameConfiguration.cs
@@ -5,19 +5,19 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Game-specific settings")]
     public class GameConfiguration : ServerSyncConfig<GameConfiguration>
     {
-        [Configuration("The games damage multiplier per person nearby in difficultyScaleRange(m) radius.")]
+        [Configuration("The games damage multiplier per person nearby in difficultyScaleRange(m) radius.", ActivationTime.Immediately)]
         public float gameDifficultyDamageScale { get; internal set; } = 0.4f;
 
-        [Configuration("The games health multiplier per person nearby in difficultyScaleRange(m) radius.")]
+        [Configuration("The games health multiplier per person nearby in difficultyScaleRange(m) radius.", ActivationTime.Immediately)]
         public float gameDifficultyHealthScale { get; internal set; } = 0.4f;
 
-        [Configuration("Adds additional players to the difficulty calculation in multiplayer unrelated to the actual amount")]
+        [Configuration("Adds additional players to the difficulty calculation in multiplayer unrelated to the actual amount", ActivationTime.Immediately)]
         public int extraPlayerCountNearby { get; internal set; } = 0;
 
-        [Configuration("Sets the nearby player count always to this value + extraPlayerCountNearby")]
+        [Configuration("Sets the nearby player count always to this value + extraPlayerCountNearby", ActivationTime.Immediately)]
         public int setFixedPlayerCountTo { get; internal set; } = 0;
 
-        [Configuration("The range in meters at which other players count towards nearby players for the difficulty scale")]
+        [Configuration("The range in meters at which other players count towards nearby players for the difficulty scale", ActivationTime.Immediately)]
         public int difficultyScaleRange { get; internal set; } = 200;
     }
 }

--- a/ValheimPlus/Configurations/Sections/GameConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/GameConfiguration.cs
@@ -1,11 +1,23 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Game-specific settings")]
     public class GameConfiguration : ServerSyncConfig<GameConfiguration>
     {
+        [Configuration("The games damage multiplier per person nearby in difficultyScaleRange(m) radius.")]
         public float gameDifficultyDamageScale { get; internal set; } = 0.4f;
+
+        [Configuration("The games health multiplier per person nearby in difficultyScaleRange(m) radius.")]
         public float gameDifficultyHealthScale { get; internal set; } = 0.4f;
+
+        [Configuration("Adds additional players to the difficulty calculation in multiplayer unrelated to the actual amount")]
         public int extraPlayerCountNearby { get; internal set; } = 0;
+
+        [Configuration("Sets the nearby player count always to this value + extraPlayerCountNearby")]
         public int setFixedPlayerCountTo { get; internal set; } = 0;
+
+        [Configuration("The range in meters at which other players count towards nearby players for the difficulty scale")]
         public int difficultyScaleRange { get; internal set; } = 200;
     }
 }

--- a/ValheimPlus/Configurations/Sections/HotkeyConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/HotkeyConfiguration.cs
@@ -1,10 +1,16 @@
-﻿using UnityEngine;
+﻿// ValheimPlus
+
+using UnityEngine;
 
 namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("https://docs.unity3d.com/ScriptReference/KeyCode.html <- a list of keycodes")]
     public class HotkeyConfiguration : BaseConfig<HotkeyConfiguration>
     {
+        [Configuration("Roll forwards on key pressed")]
         public KeyCode rollForwards { get; set; } = KeyCode.F9;
+
+        [Configuration("Roll backwards on key pressed")]
         public KeyCode rollBackwards { get; set; } = KeyCode.F10;
     }
 }

--- a/ValheimPlus/Configurations/Sections/HotkeyConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/HotkeyConfiguration.cs
@@ -7,10 +7,10 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("https://docs.unity3d.com/ScriptReference/KeyCode.html <- a list of keycodes")]
     public class HotkeyConfiguration : BaseConfig<HotkeyConfiguration>
     {
-        [Configuration("Roll forwards on key pressed")]
+        [Configuration("Roll forwards on key pressed", ActivationTime.Immediately)]
         public KeyCode rollForwards { get; set; } = KeyCode.F9;
 
-        [Configuration("Roll backwards on key pressed")]
+        [Configuration("Roll backwards on key pressed", ActivationTime.Immediately)]
         public KeyCode rollBackwards { get; set; } = KeyCode.F10;
     }
 }

--- a/ValheimPlus/Configurations/Sections/HudConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/HudConfiguration.cs
@@ -1,9 +1,16 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("HUD settings")]
     public class HudConfiguration : BaseConfig<HudConfiguration>
     {
+        [Configuration("Shows the required amount of items AND the amount of items in your inventory in build mode and while crafting.")]
         public bool showRequiredItems { get; internal set; } = false;
+
+        [Configuration("Shows small notifications about all skill experienced gained in the top left corner.")]
         public bool experienceGainedNotifications { get; internal set; } = false;
-        public float chatMessageDistance { get; internal set; }
+
+        [Configuration("not used yet")] public float chatMessageDistance { get; internal set; }
     }
 }

--- a/ValheimPlus/Configurations/Sections/HudConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/HudConfiguration.cs
@@ -5,12 +5,14 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("HUD settings")]
     public class HudConfiguration : BaseConfig<HudConfiguration>
     {
-        [Configuration("Shows the required amount of items AND the amount of items in your inventory in build mode and while crafting.")]
+        [Configuration("Shows the required amount of items AND the amount of items in your inventory in build mode and while crafting.\nNot used yet.",
+            ActivationTime.Immediately)]
         public bool showRequiredItems { get; internal set; } = false;
 
-        [Configuration("Shows small notifications about all skill experienced gained in the top left corner.")]
+        [Configuration("Shows small notifications about all skill experienced gained in the top left corner.", ActivationTime.Immediately)]
         public bool experienceGainedNotifications { get; internal set; } = false;
 
-        [Configuration("not used yet")] public float chatMessageDistance { get; internal set; }
+        [Configuration("not used yet", ActivationTime.Immediately)]
+        public float chatMessageDistance { get; internal set; }
     }
 }

--- a/ValheimPlus/Configurations/Sections/ItemsConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ItemsConfiguration.cs
@@ -1,10 +1,17 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Item settings")]
     public class ItemsConfiguration : ServerSyncConfig<ItemsConfiguration>
     {
+        [Configuration("Enables you to teleport with ores and other usually restricted objects")]
         public bool noTeleportPrevention { get; set; } = false;
+
+        [Configuration("Increase or reduce item weight by % percent. The value -50 will reduce item weight of every object by 50%.")]
         public float baseItemWeightReduction { get; set; } = 0;
+
+        [Configuration("Increase the size of all item stacks by %. The value 50 would set a usual item stack of 100 to be 150.")]
         public float itemStackMultiplier { get; internal set; } = 1;
     }
-
 }

--- a/ValheimPlus/Configurations/Sections/ItemsConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ItemsConfiguration.cs
@@ -5,13 +5,13 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Item settings")]
     public class ItemsConfiguration : ServerSyncConfig<ItemsConfiguration>
     {
-        [Configuration("Enables you to teleport with ores and other usually restricted objects")]
+        [Configuration("Enables you to teleport with ores and other usually restricted objects", ActivationTime.AfterRestartServer)]
         public bool noTeleportPrevention { get; set; } = false;
 
-        [Configuration("Increase or reduce item weight by % percent. The value -50 will reduce item weight of every object by 50%.")]
+        [Configuration("Increase or reduce item weight by % percent. The value -50 will reduce item weight of every object by 50%.", ActivationTime.AfterRestartServer)]
         public float baseItemWeightReduction { get; set; } = 0;
 
-        [Configuration("Increase the size of all item stacks by %. The value 50 would set a usual item stack of 100 to be 150.")]
+        [Configuration("Increase the size of all item stacks by %. The value 50 would set a usual item stack of 100 to be 150.", ActivationTime.AfterRestartServer)]
         public float itemStackMultiplier { get; internal set; } = 1;
     }
 }

--- a/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
@@ -5,14 +5,14 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Kiln settings")]
     public class KilnConfiguration : ServerSyncConfig<KilnConfiguration>
     {
-        [Configuration("The time it takes for the Kiln to produce a single piece of coal in seconds.")]
+        [Configuration("The time it takes for the Kiln to produce a single piece of coal in seconds.", ActivationTime.AfterRestartServer)]
         public float productionSpeed { get; set; } = 10;
 
-        [Configuration("Maximum amount of wood in a Kiln")]
+        [Configuration("Maximum amount of wood in a Kiln", ActivationTime.AfterRestartServer)]
         public int maximumWood { get; internal set; } = 25;
 
-        [Configuration("not used yet")] public bool autoDeposit { get; set; } = false;
+        [Configuration("not used yet", ActivationTime.AfterRestartServer)] public bool autoDeposit { get; set; } = false;
 
-        [Configuration("not used yet")] public float autoDepositRange { get; set; } = 10;
+        [Configuration("not used yet", ActivationTime.AfterRestartServer)] public float autoDepositRange { get; set; } = 10;
     }
 }

--- a/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
@@ -1,11 +1,18 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Kiln settings")]
     public class KilnConfiguration : ServerSyncConfig<KilnConfiguration>
     {
+        [Configuration("The time it takes for the Kiln to produce a single piece of coal in seconds.")]
         public float productionSpeed { get; set; } = 10;
-        public int maximumWood { get; internal set; } = 25;
-        public bool autoDeposit { get; set; } = false;
-        public float autoDepositRange { get; set; } = 10;
-    }
 
+        [Configuration("Maximum amount of wood in a Kiln")]
+        public int maximumWood { get; internal set; } = 25;
+
+        [Configuration("not used yet")] public bool autoDeposit { get; set; } = false;
+
+        [Configuration("not used yet")] public float autoDepositRange { get; set; } = 10;
+    }
 }

--- a/ValheimPlus/Configurations/Sections/MapConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/MapConfiguration.cs
@@ -5,19 +5,23 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Map settings")]
     public class MapConfiguration : BaseConfig<MapConfiguration>
     {
-        [Configuration("With this enabled you will receive the same exploration progression as other players on the server")]
-        public bool shareMapProgression { get; internal set; } = false;
+        [Configuration("With this enabled you will receive the same exploration progression as other players on the server", ActivationTime.Immediately)]
+        public bool shareMapProgression { get; set; } = false;
 
-        [Configuration("The radius of the map that you explore when moving")]
-        public float exploreRadius { get; internal set; } = 100;
+        [Configuration("The radius of the map that you explore when moving", ActivationTime.Immediately)]
+        public float exploreRadius { get; set; } = 100;
 
-        [Configuration("Automatically turn on the Map option to share your position when joining or starting a game")]
-        public bool playerPositionPublicOnJoin { get; internal set; } = false;
+        [Configuration("Automatically turn on the Map option to share your position when joining or starting a game", ActivationTime.AfterRelog)]
+        public bool playerPositionPublicOnJoin { get; set; } = false;
 
-        [Configuration("Prevents you and other people on the server to turn off their map sharing option")]
-        public bool preventPlayerFromTurningOffPublicPosition { get; internal set; } = false;
+        [Configuration("Prevents you and other people on the server to turn off their map sharing option", ActivationTime.Immediately)]
+        public bool preventPlayerFromTurningOffPublicPosition { get; set; } = false;
 
-        [Configuration("Remove the Map marker of your death when you have picked up your tombstone items")]
-        public bool removeDeathPinOnTombstoneEmpty { get; internal set; } = false;
+        [Configuration("Remove the Map marker of your death when you have picked up your tombstone items\nNot used yet", ActivationTime.Immediately)]
+        public bool removeDeathPinOnTombstoneEmpty { get; set; } = false;
+
+        [Configuration("Show portals automatically on map\nIf it does not activate automatically, just rename a existing portal.", ActivationTime.AfterRelog)]
+        public bool showPortalsOnMap { get; set; } = false;
+
     }
 }

--- a/ValheimPlus/Configurations/Sections/MapConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/MapConfiguration.cs
@@ -1,11 +1,23 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Map settings")]
     public class MapConfiguration : BaseConfig<MapConfiguration>
     {
+        [Configuration("With this enabled you will receive the same exploration progression as other players on the server")]
         public bool shareMapProgression { get; internal set; } = false;
+
+        [Configuration("The radius of the map that you explore when moving")]
         public float exploreRadius { get; internal set; } = 100;
+
+        [Configuration("Automatically turn on the Map option to share your position when joining or starting a game")]
         public bool playerPositionPublicOnJoin { get; internal set; } = false;
+
+        [Configuration("Prevents you and other people on the server to turn off their map sharing option")]
         public bool preventPlayerFromTurningOffPublicPosition { get; internal set; } = false;
+
+        [Configuration("Remove the Map marker of your death when you have picked up your tombstone items")]
         public bool removeDeathPinOnTombstoneEmpty { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/Configurations/Sections/MapConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/MapConfiguration.cs
@@ -5,18 +5,6 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Map settings")]
     public class MapConfiguration : BaseConfig<MapConfiguration>
     {
-        [Configuration("With this enabled you will receive the same exploration progression as other players on the server", ActivationTime.Immediately)]
-        public bool shareMapProgression { get; set; } = false;
-
-        [Configuration("The radius of the map that you explore when moving", ActivationTime.Immediately)]
-        public float exploreRadius { get; set; } = 100;
-
-        [Configuration("Automatically turn on the Map option to share your position when joining or starting a game", ActivationTime.AfterRelog)]
-        public bool playerPositionPublicOnJoin { get; set; } = false;
-
-        [Configuration("Prevents you and other people on the server to turn off their map sharing option", ActivationTime.Immediately)]
-        public bool preventPlayerFromTurningOffPublicPosition { get; set; } = false;
-
         [Configuration("Remove the Map marker of your death when you have picked up your tombstone items\nNot used yet", ActivationTime.Immediately)]
         public bool removeDeathPinOnTombstoneEmpty { get; set; } = false;
 

--- a/ValheimPlus/Configurations/Sections/MapServerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/MapServerConfiguration.cs
@@ -1,0 +1,19 @@
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
+{
+    public class MapServerConfiguration : ServerSyncConfig<MapServerConfiguration>
+    {
+        [Configuration("With this enabled you will receive the same exploration progression as other players on the server", ActivationTime.Immediately)]
+        public bool shareMapProgression { get; set; } = false;
+
+        [Configuration("The radius of the map that you explore when moving", ActivationTime.Immediately)]
+        public float exploreRadius { get; set; } = 100;
+
+        [Configuration("Automatically turn on the Map option to share your position when joining or starting a game", ActivationTime.AfterRelog)]
+        public bool playerPositionPublicOnJoin { get; set; } = false;
+
+        [Configuration("Prevents you and other people on the server to turn off their map sharing option", ActivationTime.Immediately)]
+        public bool preventPlayerFromTurningOffPublicPosition { get; set; } = false;
+    }
+}

--- a/ValheimPlus/Configurations/Sections/PlantConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlantConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
+{
+    public class PlantConfiguration : ServerSyncConfig<PlantConfiguration>
+    {
+        [Configuration("Remove biome restrictions for plant growth", ActivationTime.Immediately)]
+        public bool noWrongBiome { get; set; } = false;
+
+        [Configuration("Enable indoor growth", ActivationTime.Immediately)]
+        public bool growWithoutSun { get; set; } = false;
+
+    }
+}

--- a/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
@@ -1,12 +1,23 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Player settings")]
     public class PlayerConfiguration : ServerSyncConfig<PlayerConfiguration>
     {
+        [Configuration("The base amount of carry weight of your character")]
         public float baseMaximumWeight { get; internal set; } = 300;
-        public float baseMegingjordBuff { get; internal set; } = 150;
-        public float baseAutoPickUpRange { get; internal set; } = 2;
-        public bool disableCameraShake { get; internal set; } = false;
-        public float baseUnarmedDamage { get; internal set; } = 0;
 
+        [Configuration("Increase the buff you receive to your carry weight from Megingjord's girdle")]
+        public float baseMegingjordBuff { get; internal set; } = 150;
+
+        [Configuration("Increase auto pickup range of all items")]
+        public float baseAutoPickUpRange { get; internal set; } = 2;
+
+        [Configuration("Disable all types of camera shake")]
+        public bool disableCameraShake { get; internal set; } = false;
+
+        [Configuration("The base unarmed damage multiplied by your skill level")]
+        public float baseUnarmedDamage { get; internal set; } = 0;
     }
 }

--- a/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
@@ -5,19 +5,19 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Player settings")]
     public class PlayerConfiguration : ServerSyncConfig<PlayerConfiguration>
     {
-        [Configuration("The base amount of carry weight of your character")]
+        [Configuration("The base amount of carry weight of your character", ActivationTime.Immediately)]
         public float baseMaximumWeight { get; internal set; } = 300;
 
-        [Configuration("Increase the buff you receive to your carry weight from Megingjord's girdle")]
+        [Configuration("Increase the buff you receive to your carry weight from Megingjord's girdle", ActivationTime.Immediately)]
         public float baseMegingjordBuff { get; internal set; } = 150;
 
-        [Configuration("Increase auto pickup range of all items")]
+        [Configuration("Increase auto pickup range of all items", ActivationTime.Immediately)]
         public float baseAutoPickUpRange { get; internal set; } = 2;
 
-        [Configuration("Disable all types of camera shake")]
+        [Configuration("Disable all types of camera shake", ActivationTime.Immediately)]
         public bool disableCameraShake { get; internal set; } = false;
 
-        [Configuration("The base unarmed damage multiplied by your skill level")]
+        [Configuration("The base unarmed damage multiplied by your skill level", ActivationTime.Immediately)]
         public float baseUnarmedDamage { get; internal set; } = 0;
     }
 }

--- a/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
@@ -5,20 +5,20 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Server settings")]
     public class ServerConfiguration : ServerSyncConfig<ServerConfiguration>
     {
-        [Configuration("Modify the amount of players on your Server")]
+        [Configuration("Modify the amount of players on your Server", ActivationTime.AfterRestartServer)]
         public int maxPlayers { get; set; } = 10;
 
-        [Configuration("Removes the requirement to have a server password")]
+        [Configuration("Removes the requirement to have a server password", ActivationTime.AfterRestartServer)]
         public bool disableServerPassword { get; set; } = false;
 
         [Configuration(
-            "This settings add a version control check to make sure that people that try to join your game or the server you try to join has V+ installed")]
-        public bool enforceMod { get; internal set; } = true;
+            "This settings add a version control check to make sure that people that try to join your game or the server you try to join has V+ installed", ActivationTime.AfterRestartServer)]
+        public bool enforceMod { get; set; } = true;
 
-        [Configuration("The total amount of data that the server and client can send per second in kilobyte")]
-        public int dataRate { get; internal set; } = 60; // 614440 == 60kbs
+        [Configuration("The total amount of data that the server and client can send per second in kilobyte", ActivationTime.Immediately)]
+        public int dataRate { get; set; } = 60; // 614440 == 60kbs
 
-        [Configuration("The interval in seconds that the game auto saves at (client only)")]
-        public float autoSaveInterval { get; internal set; } = 1200;
+        [Configuration("The interval in seconds that the game auto saves at (client only)", ActivationTime.Immediately)]
+        public float autoSaveInterval { get; set; } = 1200;
     }
 }

--- a/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
@@ -3,7 +3,7 @@
 namespace ValheimPlus.Configurations.Sections
 {
     [ConfigurationSection("Server settings")]
-    public class ServerConfiguration : BaseConfig<ServerConfiguration>
+    public class ServerConfiguration : ServerSyncConfig<ServerConfiguration>
     {
         [Configuration("Modify the amount of players on your Server")]
         public int maxPlayers { get; set; } = 10;

--- a/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
@@ -1,12 +1,24 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Server settings")]
     public class ServerConfiguration : BaseConfig<ServerConfiguration>
     {
+        [Configuration("Modify the amount of players on your Server")]
         public int maxPlayers { get; set; } = 10;
+
+        [Configuration("Removes the requirement to have a server password")]
         public bool disableServerPassword { get; set; } = false;
+
+        [Configuration(
+            "This settings add a version control check to make sure that people that try to join your game or the server you try to join has V+ installed")]
         public bool enforceMod { get; internal set; } = true;
-        public int dataRate { get; internal set; } = (60 * 1024); // 614440 == 60kbs
+
+        [Configuration("The total amount of data that the server and client can send per second in kilobyte")]
+        public int dataRate { get; internal set; } = 60; // 614440 == 60kbs
+
+        [Configuration("The interval in seconds that the game auto saves at (client only)")]
         public float autoSaveInterval { get; internal set; } = 1200;
     }
-
 }

--- a/ValheimPlus/Configurations/Sections/StaminaConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StaminaConfiguration.cs
@@ -1,14 +1,32 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
-    public class StaminaConfiguration : ServerSyncConfig <StaminaConfiguration>
+    [ConfigurationSection("Stamina settings")]
+    public class StaminaConfiguration : ServerSyncConfig<StaminaConfiguration>
     {
+        [Configuration("Changes the flat amount of stamina cost of using the dodge roll")]
         public float dodgeStaminaUsage { get; internal set; } = 10;
+
+        [Configuration("Changes the stamina drain of being overweight")]
         public float encumberedStaminaDrain { get; internal set; } = 10;
+
+        [Configuration("Changes the stamina cost of jumping")]
         public float jumpStaminaDrain { get; internal set; } = 10;
+
+        [Configuration("Changes the stamina cost of running")]
         public float runStaminaDrain { get; internal set; } = 10;
+
+        [Configuration("Changes the stamina drain by sneaking")]
         public float sneakStaminaDrain { get; internal set; } = 10;
+
+        [Configuration("Changes the total amount of stamina recovered per second")]
         public float staminaRegen { get; internal set; } = 5;
+
+        [Configuration("Changes the delay until stamina regeneration sets in")]
         public float staminaRegenDelay { get; internal set; } = 0.5f;
+
+        [Configuration("Changes the stamina drain of swimming")]
         public float swimStaminaDrain { get; internal set; } = 5;
     }
 }

--- a/ValheimPlus/Configurations/Sections/StaminaConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StaminaConfiguration.cs
@@ -5,28 +5,28 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Stamina settings")]
     public class StaminaConfiguration : ServerSyncConfig<StaminaConfiguration>
     {
-        [Configuration("Changes the flat amount of stamina cost of using the dodge roll")]
-        public float dodgeStaminaUsage { get; internal set; } = 10;
+        [Configuration("Changes the flat amount of stamina cost of using the dodge roll", ActivationTime.AfterRestart)]
+        public float dodgeStaminaUsage { get; set; } = 10;
 
-        [Configuration("Changes the stamina drain of being overweight")]
-        public float encumberedStaminaDrain { get; internal set; } = 10;
+        [Configuration("Changes the stamina drain of being overweight", ActivationTime.AfterRestart)]
+        public float encumberedStaminaDrain { get; set; } = 10;
 
-        [Configuration("Changes the stamina cost of jumping")]
-        public float jumpStaminaDrain { get; internal set; } = 10;
+        [Configuration("Changes the stamina cost of jumping", ActivationTime.AfterRestart)]
+        public float jumpStaminaDrain { get; set; } = 10;
 
-        [Configuration("Changes the stamina cost of running")]
-        public float runStaminaDrain { get; internal set; } = 10;
+        [Configuration("Changes the stamina cost of running", ActivationTime.AfterRestart)]
+        public float runStaminaDrain { get; set; } = 10;
 
-        [Configuration("Changes the stamina drain by sneaking")]
-        public float sneakStaminaDrain { get; internal set; } = 10;
+        [Configuration("Changes the stamina drain by sneaking", ActivationTime.AfterRestart)]
+        public float sneakStaminaDrain { get; set; } = 10;
 
-        [Configuration("Changes the total amount of stamina recovered per second")]
-        public float staminaRegen { get; internal set; } = 5;
+        [Configuration("Changes the total amount of stamina recovered per second", ActivationTime.AfterRestart)]
+        public float staminaRegen { get; set; } = 5;
 
-        [Configuration("Changes the delay until stamina regeneration sets in")]
-        public float staminaRegenDelay { get; internal set; } = 0.5f;
+        [Configuration("Changes the delay until stamina regeneration sets in", ActivationTime.AfterRestart)]
+        public float staminaRegenDelay { get; set; } = 0.5f;
 
-        [Configuration("Changes the stamina drain of swimming")]
-        public float swimStaminaDrain { get; internal set; } = 5;
+        [Configuration("Changes the stamina drain of swimming", ActivationTime.AfterRestart)]
+        public float swimStaminaDrain { get; set; } = 5;
     }
 }

--- a/ValheimPlus/Configurations/Sections/StaminaUsageConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StaminaUsageConfiguration.cs
@@ -5,18 +5,37 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("")]
     public class StaminaUsageConfiguration : ServerSyncConfig<StaminaUsageConfiguration>
     {
-        [Configuration("Each of these values reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.")]
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float axes { get; internal set; } = 0;
 
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float bows { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float clubs { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float knives { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float pickaxes { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float polearms { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float spears { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float swords { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float unarmed { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float hammer { get; internal set; } = 0;
+
+        [Configuration("Reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.", ActivationTime.Immediately)]
         public float hoe { get; internal set; } = 0;
     }
 }

--- a/ValheimPlus/Configurations/Sections/StaminaUsageConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StaminaUsageConfiguration.cs
@@ -1,14 +1,19 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("")]
     public class StaminaUsageConfiguration : ServerSyncConfig<StaminaUsageConfiguration>
     {
-        public float axes { get; internal set; } = 0; 
+        [Configuration("Each of these values reduces the stamina drain by %. The value 50 would result in 50% less stamina cost.")]
+        public float axes { get; internal set; } = 0;
+
         public float bows { get; internal set; } = 0;
         public float clubs { get; internal set; } = 0;
         public float knives { get; internal set; } = 0;
         public float pickaxes { get; internal set; } = 0;
         public float polearms { get; internal set; } = 0;
-        public float spears { get; internal set; } = 0; 
+        public float spears { get; internal set; } = 0;
         public float swords { get; internal set; } = 0;
         public float unarmed { get; internal set; } = 0;
         public float hammer { get; internal set; } = 0;

--- a/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
@@ -1,17 +1,23 @@
 ﻿// ValheimPlus
 
+using System;
+
 namespace ValheimPlus.Configurations.Sections
 {
     [ConfigurationSection("Settings for building's structural integrity")]
     public class StructuralIntegrityConfiguration : ServerSyncConfig<StructuralIntegrityConfiguration>
     {
-        [Configuration(
-            "Each of these values reduce the loss of structural integrity by % less. The value 100 would result in disabled structural integrity and allow placement in free air.")]
+        [Configuration("Reduce the loss of structural integrity by % less. The value 100 would result in disabled structural integrity and allow placement in free air.", ActivationTime.Immediately)]
         public float wood { get; internal set; } = 0;
 
+        [Configuration("Reduce the loss of structural integrity by % less. The value 100 would result in disabled structural integrity and allow placement in free air.", ActivationTime.Immediately)]
         public float stone { get; internal set; } = 0;
+        [Configuration("Reduce the loss of structural integrity by % less. The value 100 would result in disabled structural integrity and allow placement in free air.", ActivationTime.Immediately)]
         public float iron { get; internal set; } = 0;
+        [Configuration("Reduce the loss of structural integrity by % less. The value 100 would result in disabled structural integrity and allow placement in free air.", ActivationTime.Immediately)]
         public float hardWood { get; internal set; } = 0;
+
+        [Configuration("Disable structural integrity completely", ActivationTime.Immediately)]
         public bool disableStructuralIntegrity { get; set; } = false;
     }
 }

--- a/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
@@ -1,8 +1,14 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Settings for building's structural integrity")]
     public class StructuralIntegrityConfiguration : ServerSyncConfig<StructuralIntegrityConfiguration>
     {
+        [Configuration(
+            "Each of these values reduce the loss of structural integrity by % less. The value 100 would result in disabled structural integrity and allow placement in free air.")]
         public float wood { get; internal set; } = 0;
+
         public float stone { get; internal set; } = 0;
         public float iron { get; internal set; } = 0;
         public float hardWood { get; internal set; } = 0;

--- a/ValheimPlus/Configurations/Sections/TimeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/TimeConfiguration.cs
@@ -5,10 +5,10 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Day and night length settings")]
     public class TimeConfiguration : ServerSyncConfig<TimeConfiguration>
     {
-        [Configuration("Total amount of time one complete day and night circle takes to complete")]
+        [Configuration("Total amount of time one complete day and night circle takes to complete", ActivationTime.AfterRestartServer)]
         public float totalDayTimeInSeconds { get; internal set; } = 1200;
 
-        [Configuration("Increase the speed at which time passes at night by %. The value 50 would result in a 50% reduced amount of night time.")]
+        [Configuration("Increase the speed at which time passes at night by %. The value 50 would result in a 50% reduced amount of night time.", ActivationTime.Immediately)]
         public float nightTimeSpeedMultiplier { get; internal set; } = 0;
     }
 }

--- a/ValheimPlus/Configurations/Sections/TimeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/TimeConfiguration.cs
@@ -1,8 +1,14 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Day and night length settings")]
     public class TimeConfiguration : ServerSyncConfig<TimeConfiguration>
     {
+        [Configuration("Total amount of time one complete day and night circle takes to complete")]
         public float totalDayTimeInSeconds { get; internal set; } = 1200;
+
+        [Configuration("Increase the speed at which time passes at night by %. The value 50 would result in a 50% reduced amount of night time.")]
         public float nightTimeSpeedMultiplier { get; internal set; } = 0;
     }
 }

--- a/ValheimPlus/Configurations/Sections/VagonConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/VagonConfiguration.cs
@@ -1,8 +1,15 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Wagon settings")]
     public class VagonConfiguration : ServerSyncConfig<VagonConfiguration>
     {
+        [Configuration("Change the base vagon physical mass of the vagon object\nTest 2 lines")]
         public float wagonExtraMassFromItems { get; internal set; } = 0;
+
+        [Configuration(
+            "This value changes the game physical weight of Vagons by +/- more/less from item weight inside. The value 50 would increase the weight by 50% more. The value -100 would remove the entire extra weight.")]
         public float wagonBaseMass { get; internal set; } = 20;
     }
 }

--- a/ValheimPlus/Configurations/Sections/VagonConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/VagonConfiguration.cs
@@ -5,11 +5,11 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Wagon settings")]
     public class VagonConfiguration : ServerSyncConfig<VagonConfiguration>
     {
-        [Configuration("Change the base vagon physical mass of the vagon object\nTest 2 lines")]
+        [Configuration("Change the base vagon physical mass of the vagon object", ActivationTime.Immediately)]
         public float wagonExtraMassFromItems { get; internal set; } = 0;
 
         [Configuration(
-            "This value changes the game physical weight of Vagons by +/- more/less from item weight inside. The value 50 would increase the weight by 50% more. The value -100 would remove the entire extra weight.")]
+            "This value changes the game physical weight of Vagons by +/- more/less from item weight inside.\nThe value 50 would increase the weight by 50% more. The value -100 would remove the entire extra weight.", ActivationTime.Immediately)]
         public float wagonBaseMass { get; internal set; } = 20;
     }
 }

--- a/ValheimPlus/Configurations/Sections/WardConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/WardConfiguration.cs
@@ -5,7 +5,7 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Ward settings")]
     public class WardConfiguration : ServerSyncConfig<WardConfiguration>
     {
-        [Configuration("The range of wards in meters")]
+        [Configuration("The range of wards in meters", ActivationTime.AfterRestart)]
         public float wardRange { get; internal set; } = 20;
     }
 }

--- a/ValheimPlus/Configurations/Sections/WardConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/WardConfiguration.cs
@@ -1,7 +1,11 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Ward settings")]
     public class WardConfiguration : ServerSyncConfig<WardConfiguration>
     {
+        [Configuration("The range of wards in meters")]
         public float wardRange { get; internal set; } = 20;
     }
 }

--- a/ValheimPlus/Configurations/Sections/WorkbenchConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/WorkbenchConfiguration.cs
@@ -5,10 +5,10 @@ namespace ValheimPlus.Configurations.Sections
     [ConfigurationSection("Workbench settings")]
     public class WorkbenchConfiguration : BaseConfig<WorkbenchConfiguration>
     {
-        [Configuration("Set the workbench radius in meters")]
+        [Configuration("Set the workbench radius in meters", ActivationTime.Immediately)]
         public float workbenchRange { get; internal set; } = 20;
 
-        [Configuration("Disables the roof and exposure requirement to use a workbench")]
+        [Configuration("Disables the roof and exposure requirement to use a workbench", ActivationTime.Immediately)]
         public bool disableRoofCheck { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/Configurations/Sections/WorkbenchConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/WorkbenchConfiguration.cs
@@ -1,8 +1,14 @@
-﻿namespace ValheimPlus.Configurations.Sections
+﻿// ValheimPlus
+
+namespace ValheimPlus.Configurations.Sections
 {
+    [ConfigurationSection("Workbench settings")]
     public class WorkbenchConfiguration : BaseConfig<WorkbenchConfiguration>
     {
+        [Configuration("Set the workbench radius in meters")]
         public float workbenchRange { get; internal set; } = 20;
+
+        [Configuration("Disables the roof and exposure requirement to use a workbench")]
         public bool disableRoofCheck { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
+++ b/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
@@ -14,8 +14,6 @@ namespace ValheimPlus.ConsoleCommands
         public string HelpText { get; internal set; }
         public string CommandName { get; internal set; }
 
-        private static bool isAdmin = false;
-
         public virtual bool ParseCommand(ref string input, bool silent = false)
         {
             return false;
@@ -88,17 +86,13 @@ namespace ValheimPlus.ConsoleCommands
     [HarmonyPatch(typeof(Console), "InputText")]
     public static class HookConsoleInput
     {
-        public static bool Prefix()
+        public static void Postfix()
         {
             string temp = Console.instance.m_input.text;
-            if (BaseConsoleCommand.TryExecuteCommand(ref temp))
+            if (!BaseConsoleCommand.TryExecuteCommand(ref temp))
             {
-                return false;
+                // Output something?
             }
-
-            Console.instance.m_input.text = temp;
-            return true;
         }
     }
-
 }

--- a/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
+++ b/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
@@ -1,0 +1,81 @@
+﻿// ValheimPlus
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace ValheimPlus.ConsoleCommands
+{
+    public class BaseConsoleCommand
+    {
+        public string HelpText { get; internal set; }
+        public string CommandName { get; internal set; }
+
+        public virtual bool ParseCommand(string input)
+        {
+            return false;
+        }
+
+        public bool AdminOnly { get; internal set; }
+        
+        private static List<BaseConsoleCommand> consoleCommandInstances = new List<BaseConsoleCommand>();
+
+        public static void InitializeCommand<T>() where T : BaseConsoleCommand, new()
+        {
+            if (!consoleCommandInstances.Any(x => x is T))
+            {
+                consoleCommandInstances.Add(new T());
+            }
+        }
+
+
+        public static bool TryExecuteCommand(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return false;
+            }
+
+            string[] split = input.Split(' ');
+            BaseConsoleCommand command = consoleCommandInstances.FirstOrDefault(x => String.Equals(x.CommandName, split[0], StringComparison.CurrentCultureIgnoreCase));
+            
+            if (command != null)
+            {
+                return command.ParseCommand(input);
+            }
+
+            return false;
+        }
+
+        protected static float GetFloat(string input)
+        {
+            if (!float.TryParse(input, out var val))
+            {
+                return float.NaN;
+            }
+
+            return val;
+        }
+
+        protected static int GetInt(string input)
+        {
+            if (!int.TryParse(input, out var val))
+            {
+                return int.MinValue;
+            }
+
+            return val;
+        }
+
+        protected static KeyCode GetKeyCode(string input)
+        {
+            if (System.Enum.TryParse<KeyCode>(input, out var result))
+            {
+                return result;
+            }
+
+            return KeyCode.None;
+        }
+    }
+}

--- a/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
+++ b/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
@@ -15,7 +15,7 @@ namespace ValheimPlus.ConsoleCommands
 
         private static bool isAdmin = false;
 
-        public virtual bool ParseCommand(string input, bool silent = false)
+        public virtual bool ParseCommand(ref string input, bool silent = false)
         {
             return false;
         }
@@ -30,7 +30,7 @@ namespace ValheimPlus.ConsoleCommands
             }
         }
 
-        public static bool TryExecuteCommand(string input, bool silent = false)
+        public static bool TryExecuteCommand(ref string input, bool silent = false)
         {
             if (string.IsNullOrEmpty(input))
             {
@@ -42,7 +42,7 @@ namespace ValheimPlus.ConsoleCommands
 
             if (command != null)
             {
-                return command.ParseCommand(input, silent);
+                return command.ParseCommand(ref input, silent);
             }
 
             return false;
@@ -89,12 +89,13 @@ namespace ValheimPlus.ConsoleCommands
     {
         public static bool Prefix()
         {
-            Console.instance.AddString("Hook in place!");
-            if (BaseConsoleCommand.TryExecuteCommand(Console.instance.m_input.text))
+            string temp = Console.instance.m_input.text;
+            if (BaseConsoleCommand.TryExecuteCommand(ref temp)) 
             {
                 return false;
             }
 
+            Console.instance.m_input.text = temp;
             return true;
         }
     }

--- a/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
+++ b/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
@@ -19,7 +19,7 @@ namespace ValheimPlus.ConsoleCommands
             return false;
         }
 
-        private static List<BaseConsoleCommand> consoleCommandInstances = new List<BaseConsoleCommand>();
+        internal static List<BaseConsoleCommand> consoleCommandInstances = new List<BaseConsoleCommand>();
 
         public static void InitializeCommand<T>() where T : BaseConsoleCommand, new()
         {
@@ -89,9 +89,21 @@ namespace ValheimPlus.ConsoleCommands
         public static void Postfix()
         {
             string temp = Console.instance.m_input.text;
+
+            // if help is issued, add list of our commands here
+            if (string.Equals(temp.Trim(), "help", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Console.instance.AddString("");
+                Console.instance.AddString("Valheim+ console commands:");
+                foreach (var cmd in BaseConsoleCommand.consoleCommandInstances)
+                {
+                    Console.instance.AddString(cmd.HelpText);
+                }
+            }
+
             if (!BaseConsoleCommand.TryExecuteCommand(ref temp))
             {
-                // Output something?
+                // Output something if command could not execute? not at this time.
             }
         }
     }

--- a/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
+++ b/ValheimPlus/ConsoleCommands/BaseConsoleCommand.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using HarmonyLib;
 using UnityEngine;
@@ -50,7 +51,7 @@ namespace ValheimPlus.ConsoleCommands
 
         protected static float GetFloat(string input)
         {
-            if (!float.TryParse(input, out var val))
+            if (!float.TryParse(input, NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var val))
             {
                 return float.NaN;
             }
@@ -90,7 +91,7 @@ namespace ValheimPlus.ConsoleCommands
         public static bool Prefix()
         {
             string temp = Console.instance.m_input.text;
-            if (BaseConsoleCommand.TryExecuteCommand(ref temp)) 
+            if (BaseConsoleCommand.TryExecuteCommand(ref temp))
             {
                 return false;
             }

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -24,11 +24,6 @@ namespace ValheimPlus.ConsoleCommands
 
         public override bool ParseCommand(ref string input, bool silent)
         {
-            if (!silent)
-            {
-                Console.instance.AddString(input);
-            }
-
             string inputCopy = input;
             List<string> parts = input.Replace("  "," ").Split(' ').ToList();
             string command = parts.Count >= 1 ? parts[0] : null;

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -81,7 +81,7 @@ namespace ValheimPlus.ConsoleCommands
 
                     var sectValue = sectProperty.GetValue(Configuration.Current, null);
 
-                    foreach (var prop in BaseConfig.propertyCache[sectProperty.PropertyType])
+                    foreach (var prop in BaseConfig.GetProps(sectProperty.PropertyType))
                     {
                         var val = prop.GetValue(sectValue, null);
                         Console.instance.AddString($"{prop.Name} {prop.PropertyType.Name} ({val})");
@@ -91,7 +91,7 @@ namespace ValheimPlus.ConsoleCommands
                 {
                     var sectProperty =
                         Configuration.propertyCache.FirstOrDefault(x => string.Equals(x.Name, sectionName, StringComparison.CurrentCultureIgnoreCase));
-                    var valueProp = BaseConfig.propertyCache[sectProperty.PropertyType]
+                    var valueProp = BaseConfig.GetProps(sectProperty.PropertyType)
                         .FirstOrDefault(x => string.Equals(x.Name, valueName, StringComparison.CurrentCultureIgnoreCase));
                     var ca = (ConfigurationAttribute) valueProp.GetCustomAttributes(false).FirstOrDefault(x => x is ConfigurationAttribute);
                     var valueComment = "";
@@ -139,7 +139,7 @@ namespace ValheimPlus.ConsoleCommands
 
             var needsSync = typeof(ISyncableSection).IsAssignableFrom(sectionProperty.PropertyType);
 
-            var valueProperty = BaseConfig.propertyCache[sectionProperty.PropertyType]
+            var valueProperty = BaseConfig.GetProps(sectionProperty.PropertyType)
                 .FirstOrDefault(x => string.Equals(x.Name, valueName, StringComparison.CurrentCultureIgnoreCase));
 
             if (valueProperty == null)

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -168,7 +168,7 @@ namespace ValheimPlus.ConsoleCommands
                 {
                     SyncToClients(inputCopy);
                 }
-                else if (needsSync && silent || !silent && !needsSync)
+                else if (needsSync == silent)
                 {
                     valueProperty.SetValue(section, newValue, null);
                 }
@@ -190,8 +190,9 @@ namespace ValheimPlus.ConsoleCommands
                 {
                     SyncToClients(inputCopy);
                 }
-                else if (needsSync && silent || !silent && !needsSync)
+                else if (needsSync == silent)
                 {
+                    valueProperty.GetSetMethod().Invoke(section, new object[] {newValue});
                     valueProperty.SetValue(section, newValue, null);
                 }
 
@@ -212,7 +213,7 @@ namespace ValheimPlus.ConsoleCommands
                 {
                     SyncToClients(inputCopy);
                 }
-                else if (needsSync && silent || !silent && !needsSync)
+                else if (needsSync == silent)
                 {
                     valueProperty.SetValue(section, newValue, null);
                 }
@@ -233,7 +234,7 @@ namespace ValheimPlus.ConsoleCommands
                 {
                     SyncToClients(inputCopy);
                 }
-                else if (needsSync && silent || !silent && !needsSync)
+                else if (needsSync == silent)
                 {
                     valueProperty.SetValue(section, newValue, null);
                 }

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -1,6 +1,7 @@
 ﻿// ValheimPlus
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using HarmonyLib;
@@ -17,41 +18,130 @@ namespace ValheimPlus.ConsoleCommands
             HelpText = "Set configuration values - SetValue";
 
             // TODO: Get all section names (syncables) and show list of options
-            
+
         }
 
 
-        public override bool ParseCommand(string input, bool silent)
+        public override bool ParseCommand(ref string input, bool silent)
         {
-            var split = input.Split(' ');
-            if (split.Length != 3)
+            if (!silent)
+            {
+                Console.instance.AddString(input);
+            }
+
+            string inputCopy = input;
+            List<string> parts = input.Replace("  "," ").Split(' ').ToList();
+            string command = parts.Count >= 1 ? parts[0] : null;
+            string sectionPropPart = parts.Count >= 2 ? parts[1] : null;
+            string valuePart = parts.Count == 3 ? parts[2] : null;
+
+            List<string> configParts = new List<string>();
+            string sectionName = null;
+            string valueName = null;
+            if (!string.IsNullOrEmpty(sectionPropPart))
+            {
+                configParts.AddRange(sectionPropPart.Split('.'));
+                sectionName = configParts.Count >= 1 ? configParts[0] : null;
+                valueName = configParts.Count == 2 ? configParts[1] : null;
+            }
+
+            // Set input to nothing, so it won't be added again after our messages
+            input = "";
+            if (string.IsNullOrEmpty(valueName) && string.Equals(sectionName, "help", StringComparison.CurrentCultureIgnoreCase))
+            {
+                if (!silent)
+                {
+                    Console.instance.AddString("Usage: SetValue <SectionName>.<ValueName> <value>");
+                    Console.instance.AddString("Example to set a value: SetValue Kiln.productionSpeed " + 15.7f);
+                    Console.instance.AddString("To get a list of sections: SetValue");
+                    Console.instance.AddString("To get a list of values of a section: SetValue <SectionName>");
+                    Console.instance.AddString("Info about a value: SetValue <SectionName>.<ValueName>");
+                }
+
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(sectionName))
+            {
+                Console.instance.AddString("List of configuration sections:");
+                foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    bool syncable = typeof(ISyncableSection).IsAssignableFrom(property.PropertyType);
+                    Console.instance.AddString($"{property.Name} {(syncable ? "Admin only" : "")}");
+                }
+            }
+
+
+            if (!string.IsNullOrEmpty(sectionName) && string.IsNullOrEmpty(valuePart))
+            {
+
+                if (string.IsNullOrEmpty(valueName))
+                {
+                    // write info about section
+
+                    var sectProperty = typeof(Configuration).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                        .FirstOrDefault(x => string.Equals(x.Name, sectionName, StringComparison.CurrentCultureIgnoreCase));
+                    if (sectProperty == null)
+                    {
+                        Console.instance.AddString($"No section {sectionName} available.");
+                        return false;
+                    }
+                    Console.instance.AddString($"Section {sectProperty.Name}");
+                    Console.instance.AddString("Properties:");
+
+                    var sectValue = sectProperty.GetValue(Configuration.Current, null);
+
+                    foreach (var prop in sectProperty.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(x => x.Name != "NeedsServerSync"))
+                    {
+                        var val = prop.GetValue(sectValue, null);
+                        Console.instance.AddString($"{prop.Name} {prop.PropertyType.Name} ({val})");
+                    }
+                }
+                else 
+                {
+                    var sectProperty = typeof(Configuration).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                        .FirstOrDefault(x => string.Equals(x.Name, sectionName, StringComparison.CurrentCultureIgnoreCase));
+                    var valueProp = sectProperty.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                        .FirstOrDefault(x => string.Equals(x.Name, valueName, StringComparison.CurrentCultureIgnoreCase));
+                    ConfigurationAttribute ca = (ConfigurationAttribute)valueProp.GetCustomAttributes(false).FirstOrDefault(x => x is ConfigurationAttribute);
+                    string valueComment = "";
+                    if (ca != null)
+                    {
+                        valueComment = ca.Comment;
+                    }
+                    Console.instance.AddString($"Section {sectProperty.Name} value {valueProp.Name}, type {valueProp.PropertyType.Name}");
+
+                    if (!string.IsNullOrEmpty(valueComment))
+                    {
+                        Console.instance.AddString(valueComment);
+                    }
+
+                }
+
+                return false;
+            }
+
+            if (parts.Count != 3)
             {
                 // TODO: Write error message to console
                 // Explanation   Setvalue Section.Property value
                 if (!silent)
                 {
                     Console.instance.AddString("Usage: SetValue <SectionName>.<ValueName> <value>");
-                    Console.instance.AddString("Exmample: SetValue Kiln.productionSpeed " + 15.7f);
+                    Console.instance.AddString("Example: SetValue Kiln.productionSpeed " + 15.7f);
                 }
 
                 return false;
             }
 
-            var sectionAndPropertyName = split[1];
-            var split2 = sectionAndPropertyName.Split('.');
-            if (split2.Length != 2)
-            {
-                // Also write error message to console again
-                return false;
-            }
 
             var sectionProperty = typeof(Configuration).GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .FirstOrDefault(x => string.Equals(x.Name, split2[0], StringComparison.CurrentCultureIgnoreCase));
+                .FirstOrDefault(x => string.Equals(x.Name, sectionName, StringComparison.CurrentCultureIgnoreCase));
             if (sectionProperty == null)
             {
                 if (!silent)
                 {
-                    Console.instance.AddString($"Section '{split2[0]}' does not exist.");
+                    Console.instance.AddString($"Section '{sectionName}' does not exist.");
                 }
                 return false;
             }
@@ -61,13 +151,13 @@ namespace ValheimPlus.ConsoleCommands
             var needsSync = typeof(ISyncableSection).IsAssignableFrom(sectionProperty.PropertyType);
 
             var valueProperty = sectionProperty.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .FirstOrDefault(x => string.Equals(x.Name, split2[1], StringComparison.CurrentCultureIgnoreCase));
+                .FirstOrDefault(x => string.Equals(x.Name, valueName, StringComparison.CurrentCultureIgnoreCase));
 
             if (valueProperty == null)
             {
                 if (!silent)
                 {
-                    Console.instance.AddString($"Value '{split2[1]}' does not exist in section '{split[0]}'");
+                    Console.instance.AddString($"Value '{valueName}' does not exist in section '{sectionName}'");
                 }
                 return false;
             }
@@ -76,20 +166,18 @@ namespace ValheimPlus.ConsoleCommands
 
             if (valueProperty.PropertyType == typeof(float))
             {
-                var newValue = GetFloat(split[2]);
+                var newValue = GetFloat(valuePart);
                 var oldValue = (float)valueProperty.GetValue(section, null);
 
 
                 if (!silent)
                 {
-                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                    Console.instance.AddString($"Setting {sectionName}.{valueName} to {newValue} (old: {oldValue})");
                 }
 
                 if (needsSync && !silent)
                 {
-                    ZPackage zPgk = new ZPackage();
-                    zPgk.Write(input);
-                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                    SyncToClients(inputCopy);
                 }
                 else if ((needsSync && silent) || (!silent && !needsSync))
                 {
@@ -101,19 +189,17 @@ namespace ValheimPlus.ConsoleCommands
 
             if (valueProperty.PropertyType == typeof(int))
             {
-                var newValue = GetInt(split[2]);
+                var newValue = GetInt(valuePart);
                 var oldValue = (int)valueProperty.GetValue(section, null);
 
                 if (!silent)
                 {
-                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                    Console.instance.AddString($"Setting {sectionName}.{valueName} to {newValue} (old: {oldValue})");
                 }
 
                 if (needsSync && !silent)
                 {
-                    ZPackage zPgk = new ZPackage();
-                    zPgk.Write(input);
-                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                    SyncToClients(inputCopy);
                 }
                 else if ((needsSync && silent) || (!silent && !needsSync))
                 {
@@ -125,19 +211,17 @@ namespace ValheimPlus.ConsoleCommands
 
             if (valueProperty.PropertyType == typeof(KeyCode))
             {
-                var newValue = GetKeyCode(split[2]);
+                var newValue = GetKeyCode(valuePart);
                 var oldValue = (KeyCode)valueProperty.GetValue(section, null);
 
                 if (!silent)
                 {
-                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                    Console.instance.AddString($"Setting {sectionName}.{valueName} to {newValue} (old: {oldValue})");
                 }
 
                 if (needsSync && !silent)
                 {
-                    ZPackage zPgk = new ZPackage();
-                    zPgk.Write(input);
-                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                    SyncToClients(inputCopy);
                 }
                 else if ((needsSync && silent) || (!silent && !needsSync))
                 {
@@ -149,18 +233,16 @@ namespace ValheimPlus.ConsoleCommands
 
             if (valueProperty.PropertyType == typeof(bool))
             {
-                var newValue = BaseConsoleCommand.GetBool(split[2]);
+                var newValue = BaseConsoleCommand.GetBool(valuePart);
                 var oldValue = (bool)valueProperty.GetValue(section, null);
                 if (!silent)
                 {
-                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                    Console.instance.AddString($"Setting {sectionName}.{valueName} to {newValue} (old: {oldValue})");
                 }
 
                 if (needsSync && !silent)
                 {
-                    ZPackage zPgk = new ZPackage();
-                    zPgk.Write(input);
-                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                    SyncToClients(inputCopy);
                 }
                 else if ((needsSync && silent) || (!silent && !needsSync))
                 {
@@ -174,6 +256,13 @@ namespace ValheimPlus.ConsoleCommands
             // All types should be int,float, bool or KeyCode
 
             return false;
+        }
+
+        private static void SyncToClients(string inputCopy)
+        {
+            ZPackage zPgk = new ZPackage();
+            zPgk.Write(inputCopy);
+            ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
         }
     }
 }

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -1,0 +1,98 @@
+﻿// ValheimPlus
+
+using System;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using ValheimPlus.Configurations;
+
+namespace ValheimPlus.ConsoleCommands
+{
+    public class SetConfigurationValue : BaseConsoleCommand
+    {
+        public SetConfigurationValue()
+        {
+            CommandName = "SetValue";
+            HelpText = "Set configuration values - SetValue";
+            // TODO: Get all section names (syncables) and show list of options
+            AdminOnly = true;
+        }
+
+
+        public override bool ParseCommand(string input)
+        {
+            string[] split = input.Split(' ');
+            if (split.Length != 3)
+            {
+                // TODO: Write error message to console
+                // Explanation   Setvalue Section.Property value
+                return false;
+            }
+
+            string sectionAndPropertyName = split[1];
+            string[] split2 = sectionAndPropertyName.Split('.');
+            if (split2.Length != 2)
+            {
+                // Also write error message to console again
+                return false;
+            }
+
+            PropertyInfo sectionProperty = typeof(Configuration).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .FirstOrDefault(x => String.Equals(x.Name, split2[0], StringComparison.CurrentCultureIgnoreCase));
+            if (sectionProperty == null)
+            {
+                // TODO: Write error message that the section does not exist
+                return false;
+            }
+
+            var section = sectionProperty.GetValue(Configuration.Current, null);
+
+            PropertyInfo valueProperty = sectionProperty.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .FirstOrDefault(x => String.Equals(x.Name, split2[1], StringComparison.CurrentCultureIgnoreCase));
+
+            if (valueProperty == null)
+            {
+                // TODO: Errormessage value does not exist
+                return false;
+            }
+
+            // Switch for value type
+            
+            if (valueProperty.PropertyType == typeof(float))
+            {
+                float newValue = BaseConsoleCommand.GetFloat(split[2]);
+                float oldValue = (float) valueProperty.GetValue(section, null);
+                // TODO: Write old -> new
+                valueProperty.SetValue(section, newValue, null);
+                // TODO: notify for resync
+
+                return true;
+            }
+            if (valueProperty.PropertyType == typeof(int))
+            {
+                int newValue = BaseConsoleCommand.GetInt(split[2]);
+                int oldvalue = (int) valueProperty.GetValue(section, null);
+                // TODO: Write old -> new
+                valueProperty.SetValue(section, newValue, null);
+                // TODO: notify for resync
+                
+                return true;
+            }
+            if (valueProperty.PropertyType == typeof(KeyCode))
+            {
+                KeyCode newValue = BaseConsoleCommand.GetKeyCode(split[2]);
+                KeyCode oldValue = (KeyCode)valueProperty.GetValue(section, null);
+                // TODO: Write old -> new
+                valueProperty.SetValue(section, newValue, null);
+                // TODO: notify for resync
+                
+                return true;
+            }
+
+            // If it got here, we done something weird in the configuration files
+            // All types should be int,float or KeyCode
+
+            return false;
+        }
+    }
+}

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using HarmonyLib;
 using UnityEngine;
 using ValheimPlus.Configurations;
 
@@ -14,83 +15,163 @@ namespace ValheimPlus.ConsoleCommands
         {
             CommandName = "SetValue";
             HelpText = "Set configuration values - SetValue";
+
             // TODO: Get all section names (syncables) and show list of options
-            AdminOnly = true;
+            
         }
 
 
-        public override bool ParseCommand(string input)
+        public override bool ParseCommand(string input, bool silent)
         {
-            string[] split = input.Split(' ');
+            var split = input.Split(' ');
             if (split.Length != 3)
             {
                 // TODO: Write error message to console
                 // Explanation   Setvalue Section.Property value
+                if (!silent)
+                {
+                    Console.instance.AddString("Usage: SetValue <SectionName>.<ValueName> <value>");
+                    Console.instance.AddString("Exmample: SetValue Kiln.productionSpeed " + 15.7f);
+                }
+
                 return false;
             }
 
-            string sectionAndPropertyName = split[1];
-            string[] split2 = sectionAndPropertyName.Split('.');
+            var sectionAndPropertyName = split[1];
+            var split2 = sectionAndPropertyName.Split('.');
             if (split2.Length != 2)
             {
                 // Also write error message to console again
                 return false;
             }
 
-            PropertyInfo sectionProperty = typeof(Configuration).GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .FirstOrDefault(x => String.Equals(x.Name, split2[0], StringComparison.CurrentCultureIgnoreCase));
+            var sectionProperty = typeof(Configuration).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .FirstOrDefault(x => string.Equals(x.Name, split2[0], StringComparison.CurrentCultureIgnoreCase));
             if (sectionProperty == null)
             {
-                // TODO: Write error message that the section does not exist
+                if (!silent)
+                {
+                    Console.instance.AddString($"Section '{split2[0]}' does not exist.");
+                }
                 return false;
             }
 
             var section = sectionProperty.GetValue(Configuration.Current, null);
 
-            PropertyInfo valueProperty = sectionProperty.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .FirstOrDefault(x => String.Equals(x.Name, split2[1], StringComparison.CurrentCultureIgnoreCase));
+            var needsSync = typeof(ISyncableSection).IsAssignableFrom(sectionProperty.PropertyType);
+
+            var valueProperty = sectionProperty.PropertyType.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .FirstOrDefault(x => string.Equals(x.Name, split2[1], StringComparison.CurrentCultureIgnoreCase));
 
             if (valueProperty == null)
             {
-                // TODO: Errormessage value does not exist
+                if (!silent)
+                {
+                    Console.instance.AddString($"Value '{split2[1]}' does not exist in section '{split[0]}'");
+                }
                 return false;
             }
 
             // Switch for value type
-            
+
             if (valueProperty.PropertyType == typeof(float))
             {
-                float newValue = BaseConsoleCommand.GetFloat(split[2]);
-                float oldValue = (float) valueProperty.GetValue(section, null);
-                // TODO: Write old -> new
-                valueProperty.SetValue(section, newValue, null);
-                // TODO: notify for resync
+                var newValue = GetFloat(split[2]);
+                var oldValue = (float)valueProperty.GetValue(section, null);
+
+
+                if (!silent)
+                {
+                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                }
+
+                if (needsSync && !silent)
+                {
+                    ZPackage zPgk = new ZPackage();
+                    zPgk.Write(input);
+                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                }
+                else if ((needsSync && silent) || (!silent && !needsSync))
+                {
+                    valueProperty.SetValue(section, newValue, null);
+                }
 
                 return true;
             }
+
             if (valueProperty.PropertyType == typeof(int))
             {
-                int newValue = BaseConsoleCommand.GetInt(split[2]);
-                int oldvalue = (int) valueProperty.GetValue(section, null);
-                // TODO: Write old -> new
-                valueProperty.SetValue(section, newValue, null);
-                // TODO: notify for resync
-                
+                var newValue = GetInt(split[2]);
+                var oldValue = (int)valueProperty.GetValue(section, null);
+
+                if (!silent)
+                {
+                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                }
+
+                if (needsSync && !silent)
+                {
+                    ZPackage zPgk = new ZPackage();
+                    zPgk.Write(input);
+                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                }
+                else if ((needsSync && silent) || (!silent && !needsSync))
+                {
+                    valueProperty.SetValue(section, newValue, null);
+                }
+
                 return true;
             }
+
             if (valueProperty.PropertyType == typeof(KeyCode))
             {
-                KeyCode newValue = BaseConsoleCommand.GetKeyCode(split[2]);
-                KeyCode oldValue = (KeyCode)valueProperty.GetValue(section, null);
-                // TODO: Write old -> new
-                valueProperty.SetValue(section, newValue, null);
-                // TODO: notify for resync
-                
+                var newValue = GetKeyCode(split[2]);
+                var oldValue = (KeyCode)valueProperty.GetValue(section, null);
+
+                if (!silent)
+                {
+                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                }
+
+                if (needsSync && !silent)
+                {
+                    ZPackage zPgk = new ZPackage();
+                    zPgk.Write(input);
+                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                }
+                else if ((needsSync && silent) || (!silent && !needsSync))
+                {
+                    valueProperty.SetValue(section, newValue, null);
+                }
+
+                return true;
+            }
+
+            if (valueProperty.PropertyType == typeof(bool))
+            {
+                var newValue = BaseConsoleCommand.GetBool(split[2]);
+                var oldValue = (bool)valueProperty.GetValue(section, null);
+                if (!silent)
+                {
+                    Console.instance.AddString($"Setting {split[1]} to {newValue} (old: {oldValue})");
+                }
+
+                if (needsSync && !silent)
+                {
+                    ZPackage zPgk = new ZPackage();
+                    zPgk.Write(input);
+                    ZRoutedRpc.instance.InvokeRoutedRPC("SetConfigurationValue", zPgk);
+                }
+                else if ((needsSync && silent) || (!silent && !needsSync))
+                {
+                    valueProperty.SetValue(section, newValue, null);
+                }
+
                 return true;
             }
 
             // If it got here, we done something weird in the configuration files
-            // All types should be int,float or KeyCode
+            // All types should be int,float, bool or KeyCode
 
             return false;
         }

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -15,10 +15,7 @@ namespace ValheimPlus.ConsoleCommands
         public SetConfigurationValue()
         {
             CommandName = "SetValue";
-            HelpText = "Set configuration values - SetValue";
-
-            // TODO: Get all section names (syncables) and show list of options
-
+            HelpText = "SetValue - Set configuration values, see SetValue help for more information";
         }
 
 
@@ -118,8 +115,6 @@ namespace ValheimPlus.ConsoleCommands
 
             if (parts.Count != 3)
             {
-                // TODO: Write error message to console
-                // Explanation   Setvalue Section.Property value
                 if (!silent)
                 {
                     Console.instance.AddString("Usage: SetValue <SectionName>.<ValueName> <value>");

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -52,7 +52,7 @@ namespace ValheimPlus.ConsoleCommands
                 if (!silent)
                 {
                     Console.instance.AddString("Usage: SetValue <SectionName>.<ValueName> <value>");
-                    Console.instance.AddString("Example to set a value: SetValue Kiln.productionSpeed " + 15.7f);
+                    Console.instance.AddString("Example to set a value: SetValue Kiln.productionSpeed 15.7");
                     Console.instance.AddString("To get a list of sections: SetValue");
                     Console.instance.AddString("To get a list of values of a section: SetValue <SectionName>");
                     Console.instance.AddString("Info about a value: SetValue <SectionName>.<ValueName>");
@@ -67,7 +67,7 @@ namespace ValheimPlus.ConsoleCommands
                 foreach (var property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
                 {
                     bool syncable = typeof(ISyncableSection).IsAssignableFrom(property.PropertyType);
-                    Console.instance.AddString($"{property.Name} {(syncable ? "Admin only" : "")}");
+                    Console.instance.AddString($"{property.Name} \t\t{(syncable ? "Admin only" : "")}");
                 }
             }
 

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -84,7 +84,8 @@ namespace ValheimPlus.ConsoleCommands
                     foreach (var prop in BaseConfig.GetProps(sectProperty.PropertyType))
                     {
                         var val = prop.GetValue(sectValue, null);
-                        Console.instance.AddString($"{prop.Name} {prop.PropertyType.Name} ({val})");
+                        var valDefault = ((BaseConfig)sectValue).GetDefault(sectProperty.PropertyType, prop.Name);
+                        Console.instance.AddString($"{prop.Name} {prop.PropertyType.Name} ({val}, default:{valDefault}");
                     }
                 }
                 else

--- a/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
+++ b/ValheimPlus/ConsoleCommands/SetConfigurationValue.cs
@@ -128,7 +128,7 @@ namespace ValheimPlus.ConsoleCommands
                 if (!silent)
                 {
                     Console.instance.AddString("Usage: SetValue <SectionName>.<ValueName> <value>");
-                    Console.instance.AddString("Example: SetValue Kiln.productionSpeed " + 15.7f);
+                    Console.instance.AddString("Example: SetValue Kiln.productionSpeed 15.7");
                 }
 
                 return false;
@@ -163,7 +163,6 @@ namespace ValheimPlus.ConsoleCommands
             }
 
             // Switch for value type
-
             if (valueProperty.PropertyType == typeof(float))
             {
                 var newValue = GetFloat(valuePart);

--- a/ValheimPlus/Fermenter.cs
+++ b/ValheimPlus/Fermenter.cs
@@ -8,6 +8,9 @@ namespace ValheimPlus
     {
         private static bool Prefix(ref float ___m_fermentationDuration, ref Fermenter __instance)
         {
+            // Set default value first
+            ___m_fermentationDuration = Configuration.Current.Fermenter.GetDefault<float>(nameof(Configuration.Fermenter.fermenterDuration));
+
             if (Configuration.Current.Fermenter.IsEnabled)
             {
                 float fermenterDuration = Configuration.Current.Fermenter.fermenterDuration;

--- a/ValheimPlus/Fireplace.cs
+++ b/ValheimPlus/Fireplace.cs
@@ -27,17 +27,7 @@ namespace ValheimPlus
                     }
                     else
                     {
-                        // original method
-                        float num1 = __instance.m_nview.GetZDO().GetFloat("fuel");
-                        double timeSinceLastUpdate = __instance.GetTimeSinceLastUpdate();
-                        if (__instance.IsBurning())
-                        {
-                            float num2 = (float)timeSinceLastUpdate / __instance.m_secPerFuel;
-                            float num3 = num1 - num2;
-                            if ((double)num3 <= 0.0)
-                                num3 = 0.0f;
-                            __instance.m_nview.GetZDO().Set("fuel", num3);
-                        }
+                        return true;
                     }
                 }
                 __instance.UpdateState();

--- a/ValheimPlus/Game.cs
+++ b/ValheimPlus/Game.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using HarmonyLib;
 using ValheimPlus.RPC;
-using Steamworks;
 using ValheimPlus.Configurations;
 using UnityEngine;
+using ValheimPlus.ConsoleCommands;
 
 namespace ValheimPlus
 {
@@ -14,6 +14,12 @@ namespace ValheimPlus
         {
             //Config Sync
             ZRoutedRpc.instance.Register("VPlusConfigSync", new Action<long, ZPackage>(VPlusConfigSync.RPC_VPlusConfigSync));
+
+            // Configuration console command RPC
+            ZRoutedRpc.instance.Register("SetConfigurationValue", new Action<long, ZPackage>(RPC.SetConfigurationValueRPC.RPC_SetConfigurationValue));
+
+            // register all console commands
+            BaseConsoleCommand.InitializeCommand<SetConfigurationValue>();
         }
     }
 

--- a/ValheimPlus/Humanoid.cs
+++ b/ValheimPlus/Humanoid.cs
@@ -8,11 +8,13 @@ namespace ValheimPlus
     {
         private static ItemDrop.ItemData Postfix(ItemDrop.ItemData __weapon, ref Character __instance)
         {
-            if (Configuration.Current.Player.IsEnabled)
+            if (__weapon != null)
             {
-                if (__weapon != null)
+                if (__weapon.m_shared.m_name == "Unarmed")
                 {
-                    if (__weapon.m_shared.m_name == "Unarmed")
+                    // Set default value first
+                    __weapon.m_shared.m_damages.m_blunt = __instance.GetSkillFactor(Skills.SkillType.Unarmed) * Configuration.Current.Player.GetDefault<float>(nameof(Configuration.Player.baseUnarmedDamage));
+                    if (Configuration.Current.Player.IsEnabled)
                     {
                         __weapon.m_shared.m_damages.m_blunt = __instance.GetSkillFactor(Skills.SkillType.Unarmed) * Configuration.Current.Player.baseUnarmedDamage;
                     }

--- a/ValheimPlus/Initialize.cs
+++ b/ValheimPlus/Initialize.cs
@@ -9,12 +9,12 @@ namespace ValheimPlus
 {
     // COPYRIGHT 2021 KEVIN "nx#8830" J. // http://n-x.xyz
     // GITHUB REPOSITORY https://github.com/nxPublic/ValheimPlus
-    
+
 
     [BepInPlugin("org.bepinex.plugins.valheim_plus", "Valheim Plus", "0.9.0")]
     class ValheimPlusPlugin : BaseUnityPlugin
     {
-        
+
         public static string version = "0.9.0";
         public static string newestVersion = "";
         public static Boolean isUpToDate = false;
@@ -28,12 +28,16 @@ namespace ValheimPlus
         {
             Logger.LogInfo("Trying to load the configuration file");
 
-
-            if (ConfigurationExtra.LoadSettings() != true)
+            bool isClient = !Path.GetFileName(Environment.GetCommandLineArgs()[0]).ToLower().Contains("server");
+            string msg = isClient ? "Loading client configuration" : "Loading server configuration";
+            Logger.LogInfo(msg);
+            // NEED PROPER DETECTION IF IT IS SERVER HERE
+            if (!Configuration.LoadConfiguration(isClient))
             {
                 Logger.LogError("Error while loading configuration file.");
-            }else{
-
+            }
+            else
+            {
                 Logger.LogInfo("Configuration file loaded succesfully.");
 
                 var harmony = new Harmony("mod.valheim_plus");
@@ -52,10 +56,7 @@ namespace ValheimPlus
 
                 //Logo
                 VPlusMainMenu.Load();
-
             }
-
-            
         }
     }
 }

--- a/ValheimPlus/Initialize.cs
+++ b/ValheimPlus/Initialize.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using System;
 using System.IO;
 using ValheimPlus.Configurations;
+using ValheimPlus.ConsoleCommands;
 using ValheimPlus.UI;
 
 namespace ValheimPlus
@@ -31,6 +32,7 @@ namespace ValheimPlus
             bool isClient = !Path.GetFileName(Environment.GetCommandLineArgs()[0]).ToLower().Contains("server");
             string msg = isClient ? "Loading client configuration" : "Loading server configuration";
             Logger.LogInfo(msg);
+
             // NEED PROPER DETECTION IF IT IS SERVER HERE
             if (!Configuration.LoadConfiguration(isClient))
             {

--- a/ValheimPlus/Plant.cs
+++ b/ValheimPlus/Plant.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using HarmonyLib;
+using UnityEngine.UIElements;
+using ValheimPlus.Configurations;
+
+namespace ValheimPlus
+{
+    [HarmonyPatch(typeof(Plant), "UpdateHealth")]
+    public static class PlantBiomeFix
+    {
+
+        public static void Postfix(ref Plant __instance)
+        {
+            if (Configuration.Current.Plant.IsEnabled)
+            {
+                if (Configuration.Current.Plant.noWrongBiome)
+                {
+                    if (__instance.m_status == Plant.Status.WrongBiome)
+                    {
+                        __instance.m_status = Plant.Status.Healthy;
+                    }
+                }
+
+                if (Configuration.Current.Plant.growWithoutSun)
+                {
+                    if (__instance.m_status == Plant.Status.NoSun)
+                    {
+                        __instance.m_status = Plant.Status.Healthy;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ValheimPlus/PlayerStats.cs
+++ b/ValheimPlus/PlayerStats.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using ValheimPlus.Configurations;
 using UnityEngine;
+using ValheimPlus.Configurations.Sections;
 
 namespace ValheimPlus
 {
@@ -11,7 +12,7 @@ namespace ValheimPlus
         {
             if (Configuration.Current.Stamina.IsEnabled)
             {
-                __instance.m_dodgeStaminaUsage = Configuration.Current.Stamina.dodgeStaminaUsage;;
+                __instance.m_dodgeStaminaUsage = Configuration.Current.Stamina.dodgeStaminaUsage;
                 __instance.m_encumberedStaminaDrain = Configuration.Current.Stamina.encumberedStaminaDrain;
                 __instance.m_sneakStaminaDrain = Configuration.Current.Stamina.sneakStaminaDrain;
                 __instance.m_runStaminaDrain = Configuration.Current.Stamina.runStaminaDrain;
@@ -20,21 +21,31 @@ namespace ValheimPlus
                 __instance.m_swimStaminaDrainMinSkill = Configuration.Current.Stamina.swimStaminaDrain;
                 __instance.m_jumpStaminaUsage = Configuration.Current.Stamina.jumpStaminaDrain;
             }
+
+            __instance.m_autoPickupRange = Configuration.Current.Player.GetDefault<float>(nameof(Configuration.Player.baseAutoPickUpRange));
+            __instance.m_baseCameraShake = Configuration.Current.Player.GetDefault<bool>(nameof(Configuration.Player.disableCameraShake)) ? 0f : 4f;
+
             if (Configuration.Current.Player.IsEnabled)
             {
                 __instance.m_autoPickupRange = Configuration.Current.Player.baseAutoPickUpRange;
                 __instance.m_baseCameraShake = Configuration.Current.Player.disableCameraShake ? 0f : 4f;
             }
+        }
+    }
+
+    [HarmonyPatch(typeof(Player), "UpdatePlacementGhost")]
+    public static class BuildingMaximumPlacementDistance
+    {
+        public static void Prefix(Player __instance)
+        {
+            __instance.m_maxPlaceDistance = Configuration.Current.Building.GetDefault<float>(nameof(BuildingConfiguration.maximumPlacementDistance));
+
             if (Configuration.Current.Building.IsEnabled)
             {
                 __instance.m_maxPlaceDistance = Configuration.Current.Building.maximumPlacementDistance;
             }
-
         }
-
-
     }
-
 
     [HarmonyPatch(typeof(Player), "UseStamina")]
     public static class ChangeStaminaUsageOfToolsAndWeapons
@@ -53,7 +64,7 @@ namespace ValheimPlus
                 if (__instance.GetRightItem() == null)
                     weaponType = "Unarmed";
 
-                if(weaponType != "Unarmed") 
+                if (weaponType != "Unarmed")
                 {
                     try
                     {
@@ -65,40 +76,40 @@ namespace ValheimPlus
                     isHoe = (__instance.GetRightItem().m_shared.m_name == "$item_hoe" ? true : false);
                     isHammer = (__instance.GetRightItem().m_shared.m_name == "$item_hammer" ? true : false);
                 }
-                
-                if(weaponType != "")
-                switch (weaponType)
-                {
-                    case "Swords":
-                        v = v - (v * (Configuration.Current.StaminaUsage.swords) / 100);
-                        break;
-                    case "Knives":
-                        v = v - (v * (Configuration.Current.StaminaUsage.knives) / 100);
-                        break;
-                    case "Clubs":
-                        v = v - (v * (Configuration.Current.StaminaUsage.clubs) / 100);
-                        break;
-                    case "Polearms":
-                        v = v - (v * (Configuration.Current.StaminaUsage.polearms) / 100);
-                        break;
-                    case "Spears":
-                        v = v - (v * (Configuration.Current.StaminaUsage.spears) / 100);
-                        break;
-                    case "Axes":
-                        v = v - (v * (Configuration.Current.StaminaUsage.axes) / 100);
+
+                if (weaponType != "")
+                    switch (weaponType)
+                    {
+                        case "Swords":
+                            v = v - (v * (Configuration.Current.StaminaUsage.swords) / 100);
                             break;
-                    case "Bows":
-                        v = v - (v * (Configuration.Current.StaminaUsage.bows) / 100);
-                        break;
-                    case "Unarmed":
-                        v = v - (v * (Configuration.Current.StaminaUsage.unarmed) / 100);
-                        break;
-                    case "Pickaxes":
-                        v = v - (v * (Configuration.Current.StaminaUsage.pickaxes) / 100);
-                        break;
-                    default:
-                        break;
-                }
+                        case "Knives":
+                            v = v - (v * (Configuration.Current.StaminaUsage.knives) / 100);
+                            break;
+                        case "Clubs":
+                            v = v - (v * (Configuration.Current.StaminaUsage.clubs) / 100);
+                            break;
+                        case "Polearms":
+                            v = v - (v * (Configuration.Current.StaminaUsage.polearms) / 100);
+                            break;
+                        case "Spears":
+                            v = v - (v * (Configuration.Current.StaminaUsage.spears) / 100);
+                            break;
+                        case "Axes":
+                            v = v - (v * (Configuration.Current.StaminaUsage.axes) / 100);
+                            break;
+                        case "Bows":
+                            v = v - (v * (Configuration.Current.StaminaUsage.bows) / 100);
+                            break;
+                        case "Unarmed":
+                            v = v - (v * (Configuration.Current.StaminaUsage.unarmed) / 100);
+                            break;
+                        case "Pickaxes":
+                            v = v - (v * (Configuration.Current.StaminaUsage.pickaxes) / 100);
+                            break;
+                        default:
+                            break;
+                    }
 
                 if (isHammer)
                 {

--- a/ValheimPlus/RPC/SetConfigurationValueRPC.cs
+++ b/ValheimPlus/RPC/SetConfigurationValueRPC.cs
@@ -9,26 +9,27 @@ namespace ValheimPlus.RPC
     {
         public static void RPC_SetConfigurationValue(long sender, ZPackage inputString)
         {
-            if (ZNet.m_isServer) //Server
+            if (ZNet.m_isServer) // Server
             {
-                Debug.Log("RPC_SetConfigurationValue SERVER");
-
                 var peer = ZNet.instance.GetPeer(sender);
                 if (peer == null)
                 {
                     return;
                 }
 
+                Debug.Log("RPC_SetConfigurationValue SERVER");
+                
+                // Check if peer is in admin list
                 var steamId = peer.m_socket.GetHostName();
                 if (ZNet.instance.m_adminList.Contains(steamId))
                 {
                     var input = inputString.ReadString();
-                    BaseConsoleCommand.TryExecuteCommand(input, true);
-
+                    string inputCopy = input;
+                    BaseConsoleCommand.TryExecuteCommand(ref input, true);
                     foreach (var peerEntry in ZNet.instance.m_peers)
                     {
                         // Send same back to all clients to actually also set the value on the client
-                        ZRoutedRpc.instance.InvokeRoutedRPC(peerEntry.m_uid, "SetConfigurationValue", inputString);
+                        ZRoutedRpc.instance.InvokeRoutedRPC(peerEntry.m_uid, "SetConfigurationValue", inputCopy);
                     }
                 }
             }
@@ -36,8 +37,9 @@ namespace ValheimPlus.RPC
             {
                 Debug.Log("RPC_SetConfigurationValue CLIENT");
                 var input = inputString.ReadString();
-                BaseConsoleCommand.TryExecuteCommand(input, true);
-                Console.instance.AddString($"Command '{input}' executed");
+                string inputCopy = input;
+                BaseConsoleCommand.TryExecuteCommand(ref input, true);
+                Console.instance.AddString($"Command '{inputCopy}' executed");
             }
         }
     }

--- a/ValheimPlus/RPC/SetConfigurationValueRPC.cs
+++ b/ValheimPlus/RPC/SetConfigurationValueRPC.cs
@@ -24,12 +24,13 @@ namespace ValheimPlus.RPC
                 if (ZNet.instance.m_adminList.Contains(steamId))
                 {
                     var input = inputString.ReadString();
-                    string inputCopy = input;
+                    string inputCopy = (input+" ").Trim();
                     BaseConsoleCommand.TryExecuteCommand(ref input, true);
                     foreach (var peerEntry in ZNet.instance.m_peers)
                     {
+                        Debug.Log($"SENDING {inputCopy}");
                         // Send same back to all clients to actually also set the value on the client
-                        ZRoutedRpc.instance.InvokeRoutedRPC(peerEntry.m_uid, "SetConfigurationValue", inputCopy);
+                        ZRoutedRpc.instance.InvokeRoutedRPC(peerEntry.m_uid, "SetConfigurationValue", inputString);
                     }
                 }
             }
@@ -37,7 +38,7 @@ namespace ValheimPlus.RPC
             {
                 Debug.Log("RPC_SetConfigurationValue CLIENT");
                 var input = inputString.ReadString();
-                string inputCopy = input;
+                string inputCopy = (input+" ").Trim();
                 BaseConsoleCommand.TryExecuteCommand(ref input, true);
                 Console.instance.AddString($"Command '{inputCopy}' executed");
             }

--- a/ValheimPlus/RPC/SetConfigurationValueRPC.cs
+++ b/ValheimPlus/RPC/SetConfigurationValueRPC.cs
@@ -1,0 +1,44 @@
+﻿// ValheimPlus
+
+using UnityEngine;
+using ValheimPlus.ConsoleCommands;
+
+namespace ValheimPlus.RPC
+{
+    public class SetConfigurationValueRPC
+    {
+        public static void RPC_SetConfigurationValue(long sender, ZPackage inputString)
+        {
+            if (ZNet.m_isServer) //Server
+            {
+                Debug.Log("RPC_SetConfigurationValue SERVER");
+
+                var peer = ZNet.instance.GetPeer(sender);
+                if (peer == null)
+                {
+                    return;
+                }
+
+                var steamId = peer.m_socket.GetHostName();
+                if (ZNet.instance.m_adminList.Contains(steamId))
+                {
+                    var input = inputString.ReadString();
+                    BaseConsoleCommand.TryExecuteCommand(input, true);
+
+                    foreach (var peerEntry in ZNet.instance.m_peers)
+                    {
+                        // Send same back to all clients to actually also set the value on the client
+                        ZRoutedRpc.instance.InvokeRoutedRPC(peerEntry.m_uid, "SetConfigurationValue", inputString);
+                    }
+                }
+            }
+            else // Client
+            {
+                Debug.Log("RPC_SetConfigurationValue CLIENT");
+                var input = inputString.ReadString();
+                BaseConsoleCommand.TryExecuteCommand(input, true);
+                Console.instance.AddString($"Command '{input}' executed");
+            }
+        }
+    }
+}

--- a/ValheimPlus/Server.cs
+++ b/ValheimPlus/Server.cs
@@ -21,7 +21,7 @@ namespace ValheimPlus
                 }
             }
 
-            if (Configuration.Current.Map.IsEnabled && Configuration.Current.Map.playerPositionPublicOnJoin)
+            if (Configuration.Current.Map.IsEnabled && Configuration.Current.MapServer.playerPositionPublicOnJoin)
             {
                 // Set player position visibility to public by default on server join
                 __instance.m_publicReferencePosition = true;
@@ -50,7 +50,7 @@ namespace ValheimPlus
     {
         private static void Postfix(ref bool pub, ref bool ___m_publicReferencePosition)
         {
-            if (Configuration.Current.Map.IsEnabled && Configuration.Current.Map.preventPlayerFromTurningOffPublicPosition)
+            if (Configuration.Current.Map.IsEnabled && Configuration.Current.MapServer.preventPlayerFromTurningOffPublicPosition)
             {
                 ___m_publicReferencePosition = true;
             }

--- a/ValheimPlus/Server.cs
+++ b/ValheimPlus/Server.cs
@@ -94,10 +94,11 @@ namespace ValheimPlus
         {
             if (!__instance.IsServer())
             {
-                // Load the client config file on server ZNet instance exit (server disconnect)
-                if (ConfigurationExtra.LoadSettings() != true)
+                // Load the client config file on client ZNet instance exit (server disconnect)
+                // Why? Only time it's called is on Game.Shutdown, we won't need the config anymore
+                if (Configuration.LoadConfiguration(true))
                 {
-                    Debug.LogError("Error while loading configuration file.");
+                    Debug.LogError("Error while loading server configuration files.");
                 }
             }
         }

--- a/ValheimPlus/Server.cs
+++ b/ValheimPlus/Server.cs
@@ -85,18 +85,6 @@ namespace ValheimPlus
         }
     }
 
-    
-
-    [HarmonyPatch(typeof(ZNet), "Shutdown")]
-    public static class OnErrorLoadOwnIni
-    {
-        private static void Prefix(ref ZNet __instance)
-        {
-            Configuration.Current.SaveConfiguration();
-        }
-    }
-
-
     [HarmonyPatch(typeof(FejdStartup), "IsPublicPasswordValid")]
     public static class ChangeServerPasswordBehavior
     {

--- a/ValheimPlus/Server.cs
+++ b/ValheimPlus/Server.cs
@@ -92,15 +92,7 @@ namespace ValheimPlus
     {
         private static void Prefix(ref ZNet __instance)
         {
-            if (!__instance.IsServer())
-            {
-                // Load the client config file on client ZNet instance exit (server disconnect)
-                // Why? Only time it's called is on Game.Shutdown, we won't need the config anymore
-                if (Configuration.LoadConfiguration(true))
-                {
-                    Debug.LogError("Error while loading server configuration files.");
-                }
-            }
+            Configuration.Current.SaveConfiguration();
         }
     }
 

--- a/ValheimPlus/SharedMapSystem.cs
+++ b/ValheimPlus/SharedMapSystem.cs
@@ -29,7 +29,6 @@ namespace ValheimPlus
     [HarmonyPatch(typeof(Minimap), "UpdateExplore")]
     public static class ChangeMapBehavior
     {
-
         private static void Prefix(ref float dt, ref Player player, ref Minimap __instance, ref float ___m_exploreTimer, ref float ___m_exploreInterval, ref List<ZNet.PlayerInfo> ___m_tempPlayerInfo) // Set after awake function
         {
             if (!Configuration.Current.Map.IsEnabled) return;

--- a/ValheimPlus/SharedMapSystem.cs
+++ b/ValheimPlus/SharedMapSystem.cs
@@ -33,7 +33,7 @@ namespace ValheimPlus
         {
             if (!Configuration.Current.Map.IsEnabled) return;
 
-            if (Configuration.Current.Map.shareMapProgression)
+            if (Configuration.Current.MapServer.shareMapProgression)
             {
                 float explorerTime = ___m_exploreTimer;
                 explorerTime += Time.deltaTime;
@@ -46,14 +46,14 @@ namespace ValheimPlus
                     {
                         foreach (ZNet.PlayerInfo m_Player in ___m_tempPlayerInfo)
                         {
-                            hookExplore.call_Explore(__instance, m_Player.m_position, Configuration.Current.Map.exploreRadius);
+                            hookExplore.call_Explore(__instance, m_Player.m_position, Configuration.Current.MapServer.exploreRadius);
                         }
                     }
                 }
             }
 
             // Always reveal for your own, we do this non the less to apply the potentially bigger exploreRadius
-            hookExplore.call_Explore(__instance, player.transform.position, Configuration.Current.Map.exploreRadius);
+            hookExplore.call_Explore(__instance, player.transform.position, Configuration.Current.MapServer.exploreRadius);
             
         }
     }

--- a/ValheimPlus/TeleporterOnMap.cs
+++ b/ValheimPlus/TeleporterOnMap.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HarmonyLib;
+using UnityEngine;
+using ValheimPlus.Configurations;
+
+namespace ValheimPlus
+{
+    [HarmonyPatch(typeof(Game), "Start")]
+    public static class GameStartPatchSyncTeleporterOnMap
+    {
+        private static void Prefix()
+        {
+            //Config Sync
+            ZRoutedRpc.instance.Register(nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
+                new Action<long, ZPackage>(VPlusTeleporterSync.RPC_VPlusTeleporterSync));
+        }
+    }
+
+
+    public class VPlusTeleporterSync
+    {
+        // Holder for our pins
+        public static List<Minimap.PinData> addedPins = new List<Minimap.PinData>();
+
+        // Helper to create PinData objects without adding them to the map
+        public static Minimap.PinData AddPinHelper(Vector3 pos, Minimap.PinType type, string name, bool save, bool isChecked)
+        {
+            var pinData = new Minimap.PinData();
+            pinData.m_type = type;
+            pinData.m_name = name;
+            pinData.m_pos = pos;
+            pinData.m_icon = Minimap.instance.GetSprite(type);
+            pinData.m_save = save;
+            pinData.m_checked = isChecked;
+            return pinData;
+        }
+
+
+        public static void RPC_VPlusTeleporterSync(long sender, ZPackage teleporterZPackage)
+        {
+            // SERVER SIDE
+            if (ZNet.instance.IsServer())
+            {
+                // Create package and send it to all clients
+                var package = new ZPackage();
+
+                // Collect all portal locations/names
+                var connected = new List<ZDO>();
+                var unconnected = new Dictionary<string, ZDO>();
+
+                foreach (var zdoarray in ZDOMan.instance.m_objectsBySector)
+                {
+                    if (zdoarray != null)
+                    {
+                        foreach (var zdo in zdoarray.Where(x => x.m_prefab == -661882940))
+                        {
+                            var tag = zdo.GetString("tag");
+
+                            if (!unconnected.ContainsKey(tag))
+                            {
+                                unconnected.Add(tag, zdo);
+                            }
+                            else
+                            {
+                                connected.Add(zdo);
+                                connected.Add(unconnected[tag]);
+                                unconnected.Remove(tag);
+                            }
+                        }
+                    }
+                }
+
+                package.Write(connected.Count);
+                foreach (var connectedPortal in connected)
+                {
+                    package.Write(connectedPortal.m_position);
+                    package.Write("*" + connectedPortal.GetString("tag"));
+                }
+
+                package.Write(unconnected.Count);
+                foreach (var unconnectedPortal in unconnected)
+                {
+                    package.Write(unconnectedPortal.Value.m_position);
+                    package.Write(unconnectedPortal.Value.GetString("tag"));
+                }
+
+                // Send only to single client (new peer) if zPackage is null
+                if (teleporterZPackage == null)
+                {
+                    ZLog.Log("Sending portal information to client (new peer)");
+
+                    // Send to single client (on new connections only)
+                    ZRoutedRpc.instance.InvokeRoutedRPC(sender, nameof(RPC_VPlusTeleporterSync).Substring(4), package);
+                }
+                else
+                {
+                    ZLog.Log("Sending portal information to all clients");
+                    foreach (var peer in ZNet.instance.m_peers)
+                    {
+                        if (!peer.m_server)
+                        {
+                            // Send to all clients
+                            ZRoutedRpc.instance.InvokeRoutedRPC(peer.m_uid, nameof(RPC_VPlusTeleporterSync).Substring(4), package);
+                        }
+                    }
+                }
+            }
+
+            // CLIENT SIDE
+            else
+            {
+                if (teleporterZPackage != null && teleporterZPackage.Size() > 0 && sender == ZRoutedRpc.instance.GetServerPeerID())
+                {
+                    var numConnectedPortals = teleporterZPackage.ReadInt();
+
+                    var checkList = new Dictionary<Vector3, string>();
+
+                    // prevent MT crashing
+                    lock (addedPins)
+                    {
+                        while (numConnectedPortals > 0)
+                        {
+                            var portalPosition = teleporterZPackage.ReadVector3();
+                            var portalName = teleporterZPackage.ReadString();
+
+                            checkList.Add(portalPosition, portalName);
+
+                            // Was pin already added?
+                            var foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
+                            if (foundPin != null)
+                            {
+                                // Did the pin's name change?
+                                if (foundPin.m_name != portalName)
+                                {
+                                    // Remove pin at location and readd with new name
+                                    addedPins.Remove(foundPin);
+                                    addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                                }
+                            }
+                            else
+                            {
+                                // Add new pin
+                                addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                            }
+
+                            numConnectedPortals--;
+                        }
+
+                        var numUnconnectedPortals = teleporterZPackage.ReadInt();
+
+                        while (numUnconnectedPortals > 0)
+                        {
+                            var portalPosition = teleporterZPackage.ReadVector3();
+                            var portalName = teleporterZPackage.ReadString();
+
+                            checkList.Add(portalPosition, portalName);
+
+                            // Was pin already added?
+                            var foundPin = addedPins.FirstOrDefault(x => x.m_pos == portalPosition);
+                            if (foundPin != null)
+                            {
+                                // Did the pin's name change?
+                                if (foundPin.m_name != portalName)
+                                {
+                                    // Remove pin at location and readd with new name
+                                    addedPins.Remove(foundPin);
+                                    addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                                }
+                            }
+                            else
+                            {
+                                // Add new pin
+                                addedPins.Add(AddPinHelper(portalPosition, Minimap.PinType.Icon4, portalName, false, false));
+                            }
+
+                            numUnconnectedPortals--;
+                        }
+
+                        // Remove destroyed portals from map
+                        // doesn't really react on portal destruction, only works if after a portal was destroyed, someone set the name on another portal
+                        foreach (var kv in addedPins.ToList())
+                        {
+                            if (checkList.All(x => x.Key != kv.m_pos))
+                            {
+                                addedPins.Remove(kv);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+    // React to setting tag on portal
+    // Send special Chatmessage to server
+    [HarmonyPatch(typeof(TeleportWorld), "RPC_SetTag", typeof(long), typeof(string))]
+    public static class SyncTeleporterOnMap1
+    {
+        public static void Postfix(TeleportWorld __instance, long sender, string tag)
+        {
+            if (ZNet.instance.IsServer())
+            {
+                return;
+            }
+
+            // Force sending ZDO to server
+            var temp = __instance.m_nview.GetZDO();
+
+            ZDOMan.instance.GetZDO(temp.m_uid);
+
+            ZDOMan.instance.GetPeer(ZRoutedRpc.instance.GetServerPeerID()).ForceSendZDO(temp.m_uid);
+            Task.Factory.StartNew(() =>
+            {
+                // Wait for ZDO to be sent else server won't have accurate information to send back
+                Thread.Sleep(5000);
+
+                // Send trigger to server
+                ZLog.Log("Sending message to server to trigger delivery of map icons after renaming portal");
+                ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
+                    new ZPackage());
+            });
+        }
+    }
+
+
+    // CLIENT SIDE
+    [HarmonyPatch(typeof(Minimap), "SetMapData")]
+    public static class SyncTeleporterOnMap2
+    {
+        public static void Postfix()
+        {
+            if (ZNet.m_isServer)
+            {
+                return;
+            }
+
+            if (Configuration.Current.Map.IsEnabled && Configuration.Current.Map.showPortalsOnMap)
+            {
+                ZLog.Log("Sending message to server to trigger delivery of map icons");
+                ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(VPlusTeleporterSync.RPC_VPlusTeleporterSync).Substring(4),
+                    new ZPackage());
+            }
+        }
+    }
+
+    // CLIENT SIDE Set map pins after UpdateLocationPins
+    [HarmonyPatch(typeof(Minimap), "UpdateLocationPins")]
+    public static class SyncTeleporterOnMap3
+    {
+        public static void Postfix()
+        {
+            if (ZNet.m_isServer)
+            {
+                return;
+            }
+
+            if (Configuration.Current.Map.IsEnabled && Configuration.Current.Map.showPortalsOnMap)
+            {
+                List<Minimap.PinData> copy;
+
+                lock (VPlusTeleporterSync.addedPins)
+                {
+                    copy = VPlusTeleporterSync.addedPins.ToList();
+                }
+
+                foreach (var pin in copy)
+                {
+                    var foundPin = Minimap.instance.m_pins.FirstOrDefault(x => x.m_pos == pin.m_pos);
+
+                    if (foundPin == null)
+                    {
+                        // Pin not on map, add
+                        Minimap.instance.AddPin(pin.m_pos, pin.m_type, pin.m_name, pin.m_save, pin.m_checked);
+                    }
+                    else if (foundPin.m_name != pin.m_name)
+                    {
+                        // Pin name change, remove and add new
+                        Minimap.instance.RemovePin(foundPin);
+                        Minimap.instance.AddPin(pin.m_pos, pin.m_type, pin.m_name, pin.m_save, pin.m_checked);
+                    }
+                }
+
+
+                foreach (var pin in Minimap.instance.m_pins.Where(x => !x.m_save).ToList())
+                {
+                    // Do nothing if it is a location pin
+                    if (Minimap.instance.m_locationPins.Values.Any(x => x.m_pos == pin.m_pos))
+                    {
+                        continue;
+                    }
+
+                    if (copy.All(x => x.m_pos != pin.m_pos))
+                    {
+                        Minimap.instance.RemovePin(pin);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ValheimPlus/Time.cs
+++ b/ValheimPlus/Time.cs
@@ -48,6 +48,5 @@ namespace ValheimPlus {
                 }
             }
         }
-        
     }
 }

--- a/ValheimPlus/Version.cs
+++ b/ValheimPlus/Version.cs
@@ -76,9 +76,6 @@ namespace ValheimPlus
                 Debug.Log($"Version generated : {__result}");
                 return false;
             }
-
         }
-
-
     }
 }

--- a/ValheimPlus/Ward.cs
+++ b/ValheimPlus/Ward.cs
@@ -1,19 +1,20 @@
-﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿// ValheimPlus
+
+using HarmonyLib;
 using ValheimPlus.Configurations;
 
-namespace ValheimPlus {
-    class WardPrivateArea {
+namespace ValheimPlus
+{
+    internal class WardPrivateArea
+    {
         [HarmonyPatch(typeof(PrivateArea), "Awake")]
-        public static class ModifyWardRange {
-            private static void Prefix(ref PrivateArea __instance) {
-                if (Configuration.Current.Ward.IsEnabled && Configuration.Current.Ward.wardRange > 0) 
+        public static class ModifyWardRange
+        {
+            private static void Prefix(ref PrivateArea __instance)
+            {
+                if (Configuration.Current.Ward.IsEnabled && Configuration.Current.Ward.wardRange > 0)
                 {
-                   __instance.m_radius  = Configuration.Current.Ward.wardRange;
+                    __instance.m_radius = Configuration.Current.Ward.wardRange;
                 }
             }
         }


### PR DESCRIPTION
Separating the config into different ini files serves multiple purposes.

1. Find stuff easily
2. Add non-existant values automatically on save (coming from older versions for example)

Also, the separation lets VH+ decide what to save where.
For example: 
StaminaUsage values always have to be on the server and have to be synced to the clients.
But client-only values don't need to be in the server config at all.
This approach lets players make their own customization (for example enabling advanced building mode or not) and they won't be tempted to change any server values (which would have no effect anyway, since they are synced from the server).

Another point is, changing server values ingame (via admin console commands for example) and automatically syncing to the clients.
In the previous approach everything was transferred, not distinguishing between the two different categories.

And: No more delivery of a default config file. People don't need to backup their old config and add new values by hand.
It is automatically created client and server side.
If there's a new config section, no problem, it's just written with default values on start.


Each configuration value can have it's own comment and introduction version. -> easy to spot new values, just look for the latest version number.

Let me know what you think.