### PR TITLE
Exception fix on ConfigurationExtra/getBool

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,4 +641,5 @@ Exec: https://mega.nz/file/oQxEjCJI#_XPXEjwLfv9zpcF2HRakYzepMwaUXflA9txxhx4tACA
 * TheTerrasque - https://github.com/TheTerrasque
 * Bruno Vasconcelos - https://github.com/Drakeny
 * GaelicGamer - https://github.com/GaelicGamer
+* Doudou 'xiaodoudou' - https://github.com/xiaodoudou
 * MrPurple6411#0415 - BepInEx Valheim version, AssemblyPublicizer

--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -115,7 +115,7 @@ namespace ValheimPlus.Configurations
         public static bool GetBool(this KeyDataCollection data, string key)
         {
             var truevals = new[] { "y", "yes", "true" };
-            return truevals.Contains(data[key].ToLower());
+            return truevals.Contains($"{data[key]}".ToLower());
         }
 
         public static int GetInt(this KeyDataCollection data, string key, int defaultVal)


### PR DESCRIPTION
A small fix that cast value to string to avoid exception when configuration key is missing from the INI file.