### PR TITLE
add ZNet extensions for instance scope determination

### DIFF
--- a/ValheimPlus/Utility/ZNetExtensions.cs
+++ b/ValheimPlus/Utility/ZNetExtensions.cs
@@ -1,0 +1,33 @@
+﻿public static class ZNetExtensions
+{
+    public static bool IsLocalInstance(this ZNet znet)
+    {
+        return !znet.IsDedicated() && znet.IsServer() && (znet.GetNrOfPlayers() > znet.GetPeers().Count);
+    }
+
+    public static bool IsClientInstance(this ZNet znet)
+    {
+        return !znet.IsDedicated() && !znet.IsServer();
+    }
+
+    public static bool IsServerInstance(this ZNet znet)
+    {
+        return !znet.IsLocalInstance() && !znet.IsClientInstance();
+    }
+
+    public static string GetInstanceType(this ZNet znet)
+    {
+        if (znet.IsLocalInstance())
+        {
+            return "Local";
+        } 
+        else if (znet.IsClientInstance())
+        {
+            return "Client";
+        }
+        else
+        {
+            return "Server";
+        }
+    }
+}

--- a/ValheimPlus/Utility/ZNetExtensions.cs
+++ b/ValheimPlus/Utility/ZNetExtensions.cs
@@ -1,5 +1,12 @@
 ﻿public static class ZNetExtensions
 {
+    public enum ZNetInstanceType
+    {
+        Local,
+        Client,
+        Server
+    }
+     
     public static bool IsLocalInstance(this ZNet znet)
     {
         return !znet.IsDedicated() && znet.IsServer() && (znet.GetNrOfPlayers() > znet.GetPeers().Count);
@@ -15,19 +22,19 @@
         return !znet.IsLocalInstance() && !znet.IsClientInstance();
     }
 
-    public static string GetInstanceType(this ZNet znet)
+    public static ZNetInstanceType GetInstanceType(this ZNet znet)
     {
         if (znet.IsLocalInstance())
         {
-            return "Local";
+            return ZNetInstanceType.Local;
         } 
         else if (znet.IsClientInstance())
         {
-            return "Client";
+            return ZNetInstanceType.Client;
         }
         else
         {
-            return "Server";
+            return ZNetInstanceType.Server;
         }
     }
 }

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -391,6 +391,7 @@
     <Compile Include="GameClasses\InventoryGUI.cs" />
     <Compile Include="GameClasses\CraftingStation.cs" />
     <Compile Include="Utility\Helper.cs" />
+    <Compile Include="Utility\ZNetExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
@zedle As requested. No namespace btw, so you would not have to import it to use the extension. Did not manage to test the last condition of having peers on your local instance.