### PR TITLE
Feature/free rotation with attach

### DIFF
--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -31,5 +31,6 @@ namespace ValheimPlus.Configurations
         public CameraConfiguration Camera { get; set; }
         public GameConfiguration Game { get; set; }
         public VagonConfiguration Wagon { get; set; }
+        public FreePlacementRotationConfiguration FreePlacementRotation { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/Sections/FreePlacementRotationConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FreePlacementRotationConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace ValheimPlus.Configurations.Sections
+{
+    public class FreePlacementRotationConfiguration : BaseConfig<FreePlacementRotationConfiguration>
+    {
+        public KeyCode rotateY { get; internal set; } = KeyCode.LeftAlt;
+        public KeyCode rotateX { get; internal set; } = KeyCode.C;
+        public KeyCode rotateZ { get; internal set; } = KeyCode.V;
+        
+        public KeyCode copyRotationParallel  { get; internal set; } = KeyCode.F;
+        public KeyCode copyRotationPerpendicular  { get; internal set; } = KeyCode.G;
+    }
+}

--- a/ValheimPlus/FreePlacementRotation.cs
+++ b/ValheimPlus/FreePlacementRotation.cs
@@ -1,0 +1,353 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using System.IO;
+using System.Reflection;
+using System.Runtime;
+using IniParser;
+using IniParser.Model;
+using System.Globalization;
+using Steamworks;
+using ValheimPlus;
+using UnityEngine.Rendering;
+using ValheimPlus.Configurations;
+
+namespace ValheimPlus
+{
+    /// <summary>
+    /// Rotates placementGhost by 1 angle, if pressed key, or reset to x22.5f degrees usual rotation.
+    /// Attaches to nearly placed objects as usual placement
+    /// </summary>
+    public class FreePlacementRotation
+    {
+        private static readonly Dictionary<Player, Vector3> m_placeRotationAngle = new Dictionary<Player, Vector3>();
+
+        [HarmonyPatch(typeof(Player), "UpdatePlacement")]
+        public static class ModifyPUpdatePlacement
+        {
+            private static void Postfix(Player __instance, bool takeInput, float dt)
+            {
+                if (ABM.isActive)
+                    return;
+
+                if (!__instance.InPlaceMode())
+                    return;
+
+                if (!takeInput)
+                    return;
+
+                if (Hud.IsPieceSelectionVisible())
+                    return;
+
+                if (!m_placeRotationAngle.ContainsKey(__instance))
+                    m_placeRotationAngle[__instance] = new Vector3(0, __instance.m_placeRotation, 0);
+
+                RotateWithWheel(__instance);
+                SyncRotationWithTargetInFront(__instance, Configuration.Current.FreePlacementRotation.copyRotationParallel, false);
+                SyncRotationWithTargetInFront(__instance, Configuration.Current.FreePlacementRotation.copyRotationPerpendicular, true);
+            }
+
+            private static void RotateWithWheel(Player __instance)
+            {
+                var wheel = Input.GetAxis("Mouse ScrollWheel");
+
+                if (!wheel.Equals(0f))
+                {
+                    if (Input.GetKey(Configuration.Current.FreePlacementRotation.rotateY))
+                    {
+                        m_placeRotationAngle[__instance] += Vector3.up * Mathf.Sign(wheel);
+                        __instance.m_placeRotation = (int) (m_placeRotationAngle[__instance].y / 22.5f);
+                    }
+                    else if (Input.GetKey(Configuration.Current.FreePlacementRotation.rotateX))
+                    {
+                        m_placeRotationAngle[__instance] += Vector3.right * Mathf.Sign(wheel);
+                    }
+                    else if (Input.GetKey(Configuration.Current.FreePlacementRotation.rotateZ))
+                    {
+                        m_placeRotationAngle[__instance] += Vector3.forward * Mathf.Sign(wheel);
+                    }
+                    else
+                    {
+                        __instance.m_placeRotation = ClampPlaceRotation(__instance.m_placeRotation);
+                        m_placeRotationAngle[__instance] = new Vector3(0, __instance.m_placeRotation * 22.5f, 0);
+                    }
+
+                    m_placeRotationAngle[__instance] = ClampAngles(m_placeRotationAngle[__instance]);
+
+                    Debug.Log("Angle " + m_placeRotationAngle[__instance]);
+                }
+            }
+            
+            private static bool _opposite;
+            private static Piece _lastPiece;
+            private static KeyCode _lastKeyCode;
+
+            private static void SyncRotationWithTargetInFront(Player __instance, KeyCode keyCode, bool perpendicular)
+            {
+                if (__instance.m_placementGhost == null)
+                    return;
+
+                if (Input.GetKeyUp(keyCode))
+                {
+                    Vector3 point;
+                    Vector3 normal;
+                    Piece piece;
+                    Heightmap heightmap;
+                    Collider waterSurface;
+                    if (__instance.PieceRayTest(out point, out normal, out piece, out heightmap, out waterSurface,
+                        false) && piece != null)
+                    {
+                        var rotation = piece.transform.rotation;
+                        if (perpendicular)
+                            rotation *= Quaternion.Euler(0, 90, 0);
+
+                        if (_lastKeyCode != keyCode || _lastPiece != piece)
+                            _opposite = false;
+                        
+                        _lastKeyCode = keyCode;
+                        _lastPiece = piece;
+                        
+                        if (_opposite)
+                            rotation *= Quaternion.Euler(0, 180, 0);
+                        
+                        _opposite = !_opposite;
+                        
+                        m_placeRotationAngle[__instance] = rotation.eulerAngles;
+                        Debug.Log("Sync Angle " + m_placeRotationAngle[__instance]);
+                    }
+                }
+            }
+        }
+
+        private static Vector3 ClampAngles(Vector3 angles)
+        {
+            return new Vector3(ClampAngle(angles.x), ClampAngle(angles.y), ClampAngle(angles.z));
+        }
+        
+        private static int ClampPlaceRotation(int index)
+        {
+            const int MaxIndex = 16; // 360/22.5f
+            
+            if (index < 0)
+                index = MaxIndex + index;
+            else if (index >= MaxIndex)
+                index -= MaxIndex;
+            return index;
+        }
+        
+        private static float ClampAngle(float angle)
+        {
+            if (angle < 0)
+                angle = 360 + angle;
+            else if (angle >= 360)
+                angle -= 360;
+            return angle;
+        }
+
+        [HarmonyPatch(typeof(Player), "UpdatePlacementGhost")]
+        public static class ModifyPlacingRestrictionOfGhost
+        {
+            private static void Postfix(Player __instance, bool flashGuardStone)
+            {
+                if (ABM.isActive)
+                    return;
+                
+                UpdatePlacementGhost(__instance, flashGuardStone);
+            }
+
+            private static void UpdatePlacementGhost(Player __instance, bool flashGuardStone)
+            {
+                if ((UnityEngine.Object) __instance.m_placementGhost == (UnityEngine.Object) null)
+                {
+                    if (!(bool) (UnityEngine.Object) __instance.m_placementMarkerInstance)
+                        return;
+                    __instance.m_placementMarkerInstance.SetActive(false);
+                }
+                else
+                {
+                    bool flag = ZInput.GetButton("AltPlace") || ZInput.GetButton("JoyAltPlace");
+                    Piece component1 = __instance.m_placementGhost.GetComponent<Piece>();
+                    bool water = component1.m_waterPiece || component1.m_noInWater;
+                    Vector3 point;
+                    Vector3 normal;
+                    Piece piece;
+                    Heightmap heightmap;
+                    Collider waterSurface;
+                    if (__instance.PieceRayTest(out point, out normal, out piece, out heightmap, out waterSurface, water))
+                    {
+                        __instance.m_placementStatus = Player.PlacementStatus.Valid;
+                        if ((UnityEngine.Object) __instance.m_placementMarkerInstance == (UnityEngine.Object) null)
+                            __instance.m_placementMarkerInstance =
+                                UnityEngine.Object.Instantiate<GameObject>(__instance.m_placeMarker, point,
+                                    Quaternion.identity);
+                        __instance.m_placementMarkerInstance.SetActive(true);
+                        __instance.m_placementMarkerInstance.transform.position = point;
+                        __instance.m_placementMarkerInstance.transform.rotation = Quaternion.LookRotation(normal);
+                        if (component1.m_groundOnly || component1.m_groundPiece || component1.m_cultivatedGroundOnly)
+                            __instance.m_placementMarkerInstance.SetActive(false);
+                        WearNTear wearNtear = (UnityEngine.Object) piece != (UnityEngine.Object) null
+                            ? piece.GetComponent<WearNTear>()
+                            : (WearNTear) null;
+                        StationExtension component2 = component1.GetComponent<StationExtension>();
+                        if ((UnityEngine.Object) component2 != (UnityEngine.Object) null)
+                        {
+                            CraftingStation closestStationInRange = component2.FindClosestStationInRange(point);
+                            if ((bool) (UnityEngine.Object) closestStationInRange)
+                            {
+                                component2.StartConnectionEffect(closestStationInRange);
+                            }
+                            else
+                            {
+                                component2.StopConnectionEffect();
+                                __instance.m_placementStatus = Player.PlacementStatus.ExtensionMissingStation;
+                            }
+
+                            if (component2.OtherExtensionInRange(component1.m_spaceRequirement))
+                                __instance.m_placementStatus = Player.PlacementStatus.MoreSpace;
+                        }
+
+                        if ((bool) (UnityEngine.Object) wearNtear && !wearNtear.m_supports)
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_waterPiece && (UnityEngine.Object) waterSurface == (UnityEngine.Object) null &&
+                            !flag)
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_noInWater && (UnityEngine.Object) waterSurface != (UnityEngine.Object) null)
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_groundPiece && (UnityEngine.Object) heightmap == (UnityEngine.Object) null)
+                        {
+                            __instance.m_placementGhost.SetActive(false);
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                            return;
+                        }
+
+                        if (component1.m_groundOnly && (UnityEngine.Object) heightmap == (UnityEngine.Object) null)
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_cultivatedGroundOnly &&
+                            ((UnityEngine.Object) heightmap == (UnityEngine.Object) null ||
+                             !heightmap.IsCultivated(point)))
+                            __instance.m_placementStatus = Player.PlacementStatus.NeedCultivated;
+                        if (component1.m_notOnWood && (bool) (UnityEngine.Object) piece &&
+                            (bool) (UnityEngine.Object) wearNtear &&
+                            (wearNtear.m_materialType == WearNTear.MaterialType.Wood ||
+                             wearNtear.m_materialType == WearNTear.MaterialType.HardWood))
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_notOnTiltingSurface && (double) normal.y < 0.800000011920929)
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_inCeilingOnly && (double) normal.y > -0.5)
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_notOnFloor && (double) normal.y > 0.100000001490116)
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                        if (component1.m_onlyInTeleportArea &&
+                            !(bool) (UnityEngine.Object) EffectArea.IsPointInsideArea(point, EffectArea.Type.Teleport,
+                                0.0f))
+                            __instance.m_placementStatus = Player.PlacementStatus.NoTeleportArea;
+                        if (!component1.m_allowedInDungeons && __instance.InInterior())
+                            __instance.m_placementStatus = Player.PlacementStatus.NotInDungeon;
+                        if ((bool) (UnityEngine.Object) heightmap)
+                            normal = Vector3.up;
+                        __instance.m_placementGhost.SetActive(true);
+
+                        var rotation = m_placeRotationAngle.ContainsKey(__instance)
+                            ? m_placeRotationAngle[__instance]
+                            : __instance.m_placeRotation * 22.5f * Vector3.up;
+
+                        Quaternion quaternion = Quaternion.Euler(rotation);
+                        
+                        if ((component1.m_groundPiece || component1.m_clipGround) &&
+                            (bool) (UnityEngine.Object) heightmap || component1.m_clipEverything)
+                        {
+                            if ((bool) (UnityEngine.Object) __instance.m_buildPieces.GetSelectedPrefab()
+                                    .GetComponent<TerrainModifier>() && component1.m_allowAltGroundPlacement &&
+                                (component1.m_groundPiece && !ZInput.GetButton("AltPlace")) &&
+                                !ZInput.GetButton("JoyAltPlace"))
+                            {
+                                float groundHeight = ZoneSystem.instance.GetGroundHeight(__instance.transform.position);
+                                point.y = groundHeight;
+                            }
+
+                            __instance.m_placementGhost.transform.position = point;
+                            __instance.m_placementGhost.transform.rotation = quaternion;
+                        }
+                        else
+                        {
+                            Collider[] componentsInChildren = __instance.m_placementGhost.GetComponentsInChildren<Collider>();
+                            if (componentsInChildren.Length != 0)
+                            {
+                                __instance.m_placementGhost.transform.position = point + normal * 50f;
+                                __instance.m_placementGhost.transform.rotation = quaternion;
+                                Vector3 vector3_1 = Vector3.zero;
+                                float num1 = 999999f;
+                                foreach (Collider collider in componentsInChildren)
+                                {
+                                    if (!collider.isTrigger && collider.enabled)
+                                    {
+                                        MeshCollider meshCollider = collider as MeshCollider;
+                                        if (!((UnityEngine.Object) meshCollider != (UnityEngine.Object) null) ||
+                                            meshCollider.convex)
+                                        {
+                                            Vector3 a = collider.ClosestPoint(point);
+                                            float num2 = Vector3.Distance(a, point);
+                                            if ((double) num2 < (double) num1)
+                                            {
+                                                vector3_1 = a;
+                                                num1 = num2;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                Vector3 vector3_2 = __instance.m_placementGhost.transform.position - vector3_1;
+                                if (component1.m_waterPiece)
+                                    vector3_2.y = 3f;
+                                __instance.m_placementGhost.transform.position = point + vector3_2;
+                                __instance.m_placementGhost.transform.rotation = quaternion;
+                            }
+                        }
+
+                        if (!flag)
+                        {
+                            __instance.m_tempPieces.Clear();
+                            Transform a;
+                            Transform b;
+                            if (__instance.FindClosestSnapPoints(__instance.m_placementGhost.transform, 0.5f, out a, out b,
+                                __instance.m_tempPieces))
+                            {
+                                Vector3 position = b.parent.position;
+                                Vector3 p = b.position - (a.position - __instance.m_placementGhost.transform.position);
+                                if (!__instance.IsOverlapingOtherPiece(p, __instance.m_placementGhost.name, __instance.m_tempPieces))
+                                    __instance.m_placementGhost.transform.position = p;
+                            }
+                        }
+
+                        if (Location.IsInsideNoBuildLocation(__instance.m_placementGhost.transform.position))
+                            __instance.m_placementStatus = Player.PlacementStatus.NoBuildZone;
+                        if (!PrivateArea.CheckAccess(__instance.m_placementGhost.transform.position,
+                            (bool) (UnityEngine.Object) component1.GetComponent<PrivateArea>()
+                                ? component1.GetComponent<PrivateArea>().m_radius
+                                : 0.0f, flashGuardStone))
+                            __instance.m_placementStatus = Player.PlacementStatus.PrivateZone;
+                        if (__instance.CheckPlacementGhostVSPlayers())
+                            __instance.m_placementStatus = Player.PlacementStatus.BlockedbyPlayer;
+                        if (component1.m_onlyInBiome != Heightmap.Biome.None &&
+                            (Heightmap.FindBiome(__instance.m_placementGhost.transform.position) &
+                             component1.m_onlyInBiome) == Heightmap.Biome.None)
+                            __instance.m_placementStatus = Player.PlacementStatus.WrongBiome;
+                        if (component1.m_noClipping && __instance.TestGhostClipping(__instance.m_placementGhost, 0.2f))
+                            __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                    }
+                    else
+                    {
+                        if ((bool) (UnityEngine.Object) __instance.m_placementMarkerInstance)
+                            __instance.m_placementMarkerInstance.SetActive(false);
+                        __instance.m_placementGhost.SetActive(false);
+                        __instance.m_placementStatus = Player.PlacementStatus.Invalid;
+                    }
+
+                    __instance.SetPlacementGhostValid(__instance.m_placementStatus == Player.PlacementStatus.Valid);
+                }
+            }
+        }
+    }
+}

--- a/ValheimPlus/FreePlacementRotation.cs
+++ b/ValheimPlus/FreePlacementRotation.cs
@@ -29,6 +29,9 @@ namespace ValheimPlus
         {
             private static void Postfix(Player __instance, bool takeInput, float dt)
             {
+                if (!Configuration.Current.FreePlacementRotation.IsEnabled)
+                    return;
+                
                 if (ABM.isActive)
                     return;
 
@@ -51,6 +54,9 @@ namespace ValheimPlus
 
             private static void RotateWithWheel(Player __instance)
             {
+                if (!Configuration.Current.FreePlacementRotation.IsEnabled)
+                    return;
+                
                 var wheel = Input.GetAxis("Mouse ScrollWheel");
 
                 if (!wheel.Equals(0f))

--- a/ValheimPlus/FreePlacementRotation.cs
+++ b/ValheimPlus/FreePlacementRotation.cs
@@ -17,7 +17,7 @@ using ValheimPlus.Configurations;
 namespace ValheimPlus
 {
     /// <summary>
-    /// Rotates placementGhost by 1 angle, if pressed key, or reset to x22.5f degrees usual rotation.
+    /// Rotates placementGhost by 1 degree, if pressed key, or reset to x22.5f degrees usual rotation.
     /// Attaches to nearly placed objects as usual placement
     /// </summary>
     public class FreePlacementRotation

--- a/ValheimPlus/FreePlacementRotation.cs
+++ b/ValheimPlus/FreePlacementRotation.cs
@@ -163,6 +163,8 @@ namespace ValheimPlus
                 UpdatePlacementGhost(__instance, flashGuardStone);
             }
 
+            // almost copy of original UpdatePlacementGhost with modified calculation of Quaternion quaternion = Quaternion.Euler(rotation);
+            // need to be re-calculated in Postfix for correct work of auto-attachment of placementGhost after change rotation
             private static void UpdatePlacementGhost(Player __instance, bool flashGuardStone)
             {
                 if ((UnityEngine.Object) __instance.m_placementGhost == (UnityEngine.Object) null)

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -367,3 +367,19 @@ wagonBaseMass=20
 
 ; This value changes the game physical weight of Vagons by +/- more/less from item weight inside. The value 50 would increase the weight by 50% more. The value -100 would remove the entire extra weight.
 wagonExtraMassFromItems=0
+
+[FreePlacementRotation]
+
+; Change false to true to enable this section, if you set this to false the mode will not be accesible
+enabled=true
+
+; Rotates placement marker by 1 degree with keep ability to attach to nearly pieces
+rotateY=LeftAlt
+rotateX=C
+rotateZ=V
+
+; Copy rotation of placement marker from target piece in front of you
+copyRotationParallel=F
+
+; Set rotation to be perpendicular to piece in front of you
+copyRotationPerpendicular=G


### PR DESCRIPTION
Rotates placementGhost by 1 degree, if pressed key, or reset to usual rotation x22.5f degrees, if rotate without key pressed.
Unlike in your AdvancedBuildingMode, this variant still use auto-attachment to nearly objects.
Also, it saves rotation prom previous placement, so you can qickly place a lot of objects in line with un-standard rotation.
Also, added hot keys to copy rotation from target piece, and another to set rotation as perpendicular to selected piece.

Actually, you can attach to it yout Num+ and Num- scale functionality.