### PR TITLE
Correction for stamina usage description

### DIFF
--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -377,7 +377,7 @@ swimStaminaDrain=0
 [StaminaUsage]
 ; Change false to true to enable this section
 enabled=false
-; Each of these values reduces the stamina drain by %.
+; Each of these values modifies the stamina drain by %.
 ; The value 50 would result in 50% more stamina cost.
 ; The value -50 would result in 50% less stamina cost.
 axes=0


### PR DESCRIPTION
Replaced the comment "; Each of these values reduces the stamina drain by %." to "; Each of these values modifies the stamina drain by a percentage %."