### PR TITLE
Bug/sleep fix

### DIFF
--- a/ValheimPlus/Configurations/Sections/TimeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/TimeConfiguration.cs
@@ -2,7 +2,7 @@
 {
     public class TimeConfiguration : ServerSyncConfig<TimeConfiguration>
     {
-        public float totalDayTimeInSeconds { get; internal set; } = 1200;
+        public float totalDayTimeInSeconds { get; internal set; } = 1800;
         public float nightTimeSpeedMultiplier { get; internal set; } = 0;
     }
 }

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -6,7 +6,6 @@ namespace ValheimPlus
 {
     public class TimeManipulation
     {
-        /*
         /// <summary>
         /// Hook on EnvMan FixedUpdate to adjust dayLengthSec
         /// </summary>
@@ -44,6 +43,5 @@ namespace ValheimPlus
                 }
             }
         }
-        */
     }
 }

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -101,7 +101,7 @@ namespace ValheimPlus
                 if (ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && __instance.IsNight())
                 {
                     double timeSeconds = ZNet.instance.GetTimeSeconds();
-                    double num = timeSeconds + Helper.applyModifierValue(Time.deltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier);
+                    double num = timeSeconds + Helper.applyModifierValue(Time.fixedDeltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier);
                     ZNet.instance.SetNetTime(num);
                 }
             }

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -92,7 +92,7 @@ namespace ValheimPlus
                 if (!Configuration.Current.Time.IsEnabled) {
                     return;
                 }
-                if (ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && __instance.IsNight()) {
+                if (ZNet.instance != null && ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && __instance.IsNight()) {
                     double timeSeconds = ZNet.instance.GetTimeSeconds();
                     double num = timeSeconds + Helper.applyModifierValue(Time.fixedDeltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier);
                     ZNet.instance.SetNetTime(num);

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -96,14 +96,11 @@ namespace ValheimPlus
                 {
                     return;
                 }
-                if (!__instance.IsTimeSkipping() && __instance.IsNight())
+                if (ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && __instance.IsNight())
                 {
-                    if (ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0)
-                    {
-                        double timeSeconds = ZNet.instance.GetTimeSeconds();
-                        double num = timeSeconds + Helper.applyModifierValue(Time.deltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier);
-                        ZNet.instance.SetNetTime(num);
-                    }
+                    double timeSeconds = ZNet.instance.GetTimeSeconds();
+                    double num = timeSeconds + Helper.applyModifierValue(Time.deltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier);
+                    ZNet.instance.SetNetTime(num);
                 }
             }
         }

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -20,6 +20,7 @@ namespace ValheimPlus
             }
         }
 
+        // Refer to assembly_valheim/EnvMan IsDay/IsAfternoon/IsNight
         private const float startOfADay = 0.25f;
         private const float startOfNight = 0.75f;
         private const float startOfAfternoon = 0.5f;
@@ -43,30 +44,39 @@ namespace ValheimPlus
             }
         }
 
+        /// <summary>
+        /// Hook on EnvMan IsDay to avoid fraction methods on the server side
+        /// </summary>
         [HarmonyPatch(typeof(EnvMan), "IsDay")]
         class EnvMan_IsDay_Patch {
             static void Postfix(ref bool __result) {
-                if (ZNet.instance.IsServer()) {
+                if (Configuration.Current.Time.IsEnabled && ZNet.instance != null && ZNet.instance.IsServer()) {
                     double progression = GetDayProgression();
                     __result = progression >= startOfADay && progression <= startOfNight;
                 }
             }
         }
 
+        /// <summary>
+        /// Hook on EnvMan IsNight to avoid fraction methods on the server side
+        /// </summary>
         [HarmonyPatch(typeof(EnvMan), "IsNight")]
         class EnvMan_IsNight_Patch {
             static void Postfix(ref bool __result) {
-                if (ZNet.instance.IsServer()) {
+                if (Configuration.Current.Time.IsEnabled && ZNet.instance != null && ZNet.instance.IsServer()) {
                     double progression = GetDayProgression();
                     __result = progression <= startOfADay || progression >= startOfNight;
                 }
             }
         }
 
+        /// <summary>
+        /// Hook on EnvMan IsAfternoon to avoid fraction methods on the server side
+        /// </summary>
         [HarmonyPatch(typeof(EnvMan), "IsAfternoon")]
         class EnvMan_IsAfternoon_Patch {
             static void Postfix(ref bool __result) {
-                if (ZNet.instance.IsServer()) {
+                if (Configuration.Current.Time.IsEnabled && ZNet.instance != null && ZNet.instance.IsServer()) {
                     double progression = GetDayProgression();
                     __result = progression >= startOfAfternoon && progression <= startOfNight;
                 }

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -10,13 +10,11 @@ namespace ValheimPlus
         /// Alter the total day length in seconds base on configuration file
         /// </summary>
         public static void SetupDayLength() {
-            if (Configuration.Current.Time.IsEnabled) {
-                EnvMan instance = EnvMan.m_instance;
-                if (instance) {
-                    instance.m_dayLengthSec = (long)Configuration.Current.Time.totalDayTimeInSeconds;
-                } else {
-                    Debug.LogWarning("EnvMan instance not loaded");
-                }
+            EnvMan instance = EnvMan.m_instance;
+            if (instance) {
+                instance.m_dayLengthSec = (long)Configuration.Current.Time.totalDayTimeInSeconds;
+            } else {
+                Debug.LogWarning("EnvMan instance not loaded");
             }
         }
 
@@ -40,7 +38,10 @@ namespace ValheimPlus
         [HarmonyPatch(typeof(EnvMan), "Awake")]
         public static class EnvMan_Awake_Patch {
             private static void Prefix(ref EnvMan __instance) {
-                SetupDayLength();
+                if (Configuration.Current.Time.IsEnabled)
+                {
+                    SetupDayLength();
+                }
             }
         }
 

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -25,6 +25,13 @@ namespace ValheimPlus
             }
         }
 
+        private const float startOfADay = 0.25f;
+        private const float startOfNight = 0.75f;
+        private const float startOfAfternoon = 0.5f;
+
+        /// <summary>
+        /// Return progression of the day on a range of 0 to 1
+        /// </summary>
         public static double GetDayProgression()
         {
             double timeSecondsFromStart = ZNet.instance.GetTimeSeconds();
@@ -36,7 +43,7 @@ namespace ValheimPlus
         /// Hook on EnvMan init to alter total day length
         /// </summary>
         [HarmonyPatch(typeof(EnvMan), "Awake")]
-        public static class TimeInitHook
+        public static class EnvMan_Awake_Patch
         {
             private static void Prefix(ref EnvMan __instance)
             {
@@ -52,7 +59,7 @@ namespace ValheimPlus
                 if (ZNet.instance.IsServer())
                 {
                     double progression = GetDayProgression();
-                    result = progression >= 0.25f && progression <= 0.75f;
+                    result = progression >= startOfADay && progression <= startOfNight;
                 }
                 return result;
             }
@@ -66,7 +73,7 @@ namespace ValheimPlus
                 if (ZNet.instance.IsServer())
                 {
                     double progression = GetDayProgression();
-                    result = progression <= 0.25f || progression >= 0.75f;
+                    result = progression <= startOfADay || progression >= startOfNight;
                 }
                 return result;
             }
@@ -80,7 +87,7 @@ namespace ValheimPlus
                 if (ZNet.instance.IsServer())
                 {
                     double progression = GetDayProgression();
-                    result = progression >= 0.5f && progression <= 0.75f;
+                    result = progression >= startOfAfternoon && progression <= startOfNight;
                 }
                 return result;
             }
@@ -90,7 +97,7 @@ namespace ValheimPlus
         /// Hook on EnvMan to alter night speed
         /// </summary>
         [HarmonyPatch(typeof(EnvMan), "FixedUpdate")]
-        public static class TimeUpdateHook
+        public static class EnvMan_FixedUpdate_Patch
         {
             private static void Prefix(ref EnvMan __instance)
             {

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -9,17 +9,12 @@ namespace ValheimPlus
         /// <summary>
         /// Alter the total day length in seconds base on configuration file
         /// </summary>
-        public static void SetupDayLength()
-        {
-            if (Configuration.Current.Time.IsEnabled)
-            {
+        public static void SetupDayLength() {
+            if (Configuration.Current.Time.IsEnabled) {
                 EnvMan instance = EnvMan.m_instance;
-                if (instance)
-                {
+                if (instance) {
                     instance.m_dayLengthSec = (long)Configuration.Current.Time.totalDayTimeInSeconds;
-                }
-                else
-                {
+                } else {
                     Debug.LogWarning("EnvMan instance not loaded");
                 }
             }
@@ -32,8 +27,7 @@ namespace ValheimPlus
         /// <summary>
         /// Return progression of the day on a range of 0 to 1
         /// </summary>
-        public static double GetDayProgression()
-        {
+        public static double GetDayProgression() {
             double timeSecondsFromStart = ZNet.instance.GetTimeSeconds();
             double timeSecondsFromDay = timeSecondsFromStart % Configuration.Current.Time.totalDayTimeInSeconds;
             return timeSecondsFromDay / Configuration.Current.Time.totalDayTimeInSeconds;
@@ -43,53 +37,39 @@ namespace ValheimPlus
         /// Hook on EnvMan init to alter total day length
         /// </summary>
         [HarmonyPatch(typeof(EnvMan), "Awake")]
-        public static class EnvMan_Awake_Patch
-        {
-            private static void Prefix(ref EnvMan __instance)
-            {
+        public static class EnvMan_Awake_Patch {
+            private static void Prefix(ref EnvMan __instance) {
                 SetupDayLength();
             }
         }
 
         [HarmonyPatch(typeof(EnvMan), "IsDay")]
-        class EnvMan_IsDay_Patch
-        {
-            static bool Postfix(bool result)
-            {
-                if (ZNet.instance.IsServer())
-                {
+        class EnvMan_IsDay_Patch {
+            static void Postfix(ref bool __result) {
+                if (ZNet.instance.IsServer()) {
                     double progression = GetDayProgression();
-                    result = progression >= startOfADay && progression <= startOfNight;
+                    __result = progression >= startOfADay && progression <= startOfNight;
                 }
-                return result;
             }
         }
 
         [HarmonyPatch(typeof(EnvMan), "IsNight")]
-        class EnvMan_IsNight_Patch
-        {
-            static bool Postfix(bool result)
-            {
-                if (ZNet.instance.IsServer())
-                {
+        class EnvMan_IsNight_Patch {
+            static void Postfix(ref bool __result) {
+                if (ZNet.instance.IsServer()) {
                     double progression = GetDayProgression();
-                    result = progression <= startOfADay || progression >= startOfNight;
+                    __result = progression <= startOfADay || progression >= startOfNight;
                 }
-                return result;
             }
         }
 
         [HarmonyPatch(typeof(EnvMan), "IsAfternoon")]
-        class EnvMan_IsAfternoon_Patch
-        {
-            static bool Postfix(bool result)
-            {
-                if (ZNet.instance.IsServer())
-                {
+        class EnvMan_IsAfternoon_Patch {
+            static void Postfix(ref bool __result) {
+                if (ZNet.instance.IsServer()) {
                     double progression = GetDayProgression();
-                    result = progression >= startOfAfternoon && progression <= startOfNight;
+                    __result = progression >= startOfAfternoon && progression <= startOfNight;
                 }
-                return result;
             }
         }
 
@@ -97,16 +77,12 @@ namespace ValheimPlus
         /// Hook on EnvMan to alter night speed
         /// </summary>
         [HarmonyPatch(typeof(EnvMan), "FixedUpdate")]
-        public static class EnvMan_FixedUpdate_Patch
-        {
-            private static void Prefix(ref EnvMan __instance)
-            {
-                if (!Configuration.Current.Time.IsEnabled)
-                {
+        public static class EnvMan_FixedUpdate_Patch {
+            private static void Prefix(ref EnvMan __instance) {
+                if (!Configuration.Current.Time.IsEnabled) {
                     return;
                 }
-                if (ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && __instance.IsNight())
-                {
+                if (ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && __instance.IsNight()) {
                     double timeSeconds = ZNet.instance.GetTimeSeconds();
                     double num = timeSeconds + Helper.applyModifierValue(Time.fixedDeltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier);
                     ZNet.instance.SetNetTime(num);

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -7,96 +7,39 @@ namespace ValheimPlus
     public class TimeManipulation
     {
         /// <summary>
-        /// Alter the total day length in seconds base on configuration file
-        /// </summary>
-        public static void SetupDayLength() {
-            EnvMan instance = EnvMan.m_instance;
-            if (instance) {
-                instance.m_dayLengthSec = (long)Configuration.Current.Time.totalDayTimeInSeconds;
-            } else {
-                Debug.LogWarning("EnvMan instance not loaded");
-            }
-        }
-
-        // Refer to assembly_valheim/EnvMan IsDay/IsAfternoon/IsNight
-        private const float startOfADay = 0.25f;
-        private const float startOfNight = 0.75f;
-        private const float startOfAfternoon = 0.5f;
-
-        /// <summary>
-        /// Return progression of the day on a range of 0 to 1
-        /// </summary>
-        public static double GetDayProgression() {
-            double timeSecondsFromStart = ZNet.instance.GetTimeSeconds();
-            double timeSecondsFromDay = timeSecondsFromStart % Configuration.Current.Time.totalDayTimeInSeconds;
-            return timeSecondsFromDay / Configuration.Current.Time.totalDayTimeInSeconds;
-        }
-
-        /// <summary>
-        /// Hook on EnvMan init to alter total day length
-        /// </summary>
-        [HarmonyPatch(typeof(EnvMan), "Awake")]
-        public static class EnvMan_Awake_Patch {
-            private static void Prefix(ref EnvMan __instance) {
-                if (Configuration.Current.Time.IsEnabled)
-                {
-                    SetupDayLength();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Hook on EnvMan IsDay to avoid fraction methods on the server side
-        /// </summary>
-        [HarmonyPatch(typeof(EnvMan), "IsDay")]
-        class EnvMan_IsDay_Patch {
-            static void Postfix(ref bool __result) {
-                if (Configuration.Current.Time.IsEnabled && ZNet.instance != null && ZNet.instance.IsServer()) {
-                    double progression = GetDayProgression();
-                    __result = progression >= startOfADay && progression <= startOfNight;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Hook on EnvMan IsNight to avoid fraction methods on the server side
-        /// </summary>
-        [HarmonyPatch(typeof(EnvMan), "IsNight")]
-        class EnvMan_IsNight_Patch {
-            static void Postfix(ref bool __result) {
-                if (Configuration.Current.Time.IsEnabled && ZNet.instance != null && ZNet.instance.IsServer()) {
-                    double progression = GetDayProgression();
-                    __result = progression <= startOfADay || progression >= startOfNight;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Hook on EnvMan IsAfternoon to avoid fraction methods on the server side
-        /// </summary>
-        [HarmonyPatch(typeof(EnvMan), "IsAfternoon")]
-        class EnvMan_IsAfternoon_Patch {
-            static void Postfix(ref bool __result) {
-                if (Configuration.Current.Time.IsEnabled && ZNet.instance != null && ZNet.instance.IsServer()) {
-                    double progression = GetDayProgression();
-                    __result = progression >= startOfAfternoon && progression <= startOfNight;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Hook on EnvMan to alter night speed
+        /// Hook on EnvMan FixedUpdate to adjust dayLengthSec
         /// </summary>
         [HarmonyPatch(typeof(EnvMan), "FixedUpdate")]
-        public static class EnvMan_FixedUpdate_Patch {
-            private static void Prefix(ref EnvMan __instance) {
-                if (!Configuration.Current.Time.IsEnabled) {
-                    return;
+        class EnvMan_FixedUpdate_Patch
+        {
+            private static void Prefix(ref EnvMan __instance)
+            {
+                if (Configuration.Current.Time.IsEnabled)
+                {
+                    __instance.m_dayLengthSec = (long)(Configuration.Current.Time.totalDayTimeInSeconds * (2f / 3f)); // A day length in valhein is 2/3 of a human full day cycle
+                } else
+                {
+                    __instance.m_dayLengthSec = 1200L; // Default valheim value
                 }
-                if (ZNet.instance != null && ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && __instance.IsNight()) {
-                    double timeSeconds = ZNet.instance.GetTimeSeconds();
-                    double num = timeSeconds + Helper.applyModifierValue(Time.fixedDeltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier);
-                    ZNet.instance.SetNetTime(num);
+            }
+        }
+
+
+        /// <summary>
+        /// Hook on EnvMan RescaleDayFraction to adjust nightTime + dayLengthSec
+        /// </summary>
+        [HarmonyPatch(typeof(EnvMan), "RescaleDayFraction")]
+        class EnvMan_RescaleDayFraction_Patch
+        {
+            static void Prefix(ref EnvMan __instance, float fraction, ref float __result)
+            {
+                if (ZNet.instance != null && ZNet.instance.IsServer() && ZNet.instance.GetNrOfPlayers() > 0 && !__instance.IsTimeSkipping() && Configuration.Current.Time.IsEnabled)
+                {
+                    // If Night (late night / early morning) or Night (early night)
+                    if (fraction < 0.15f || fraction > 0.85f) 
+                    {
+                        ZNet.instance.m_netTime += Helper.applyModifierValue(Time.fixedDeltaTime, Configuration.Current.Time.nightTimeSpeedMultiplier); // If out of sync; server every 2s resync netTime
+                    }
                 }
             }
         }

--- a/ValheimPlus/RPC/VPlusConfigSync.cs
+++ b/ValheimPlus/RPC/VPlusConfigSync.cs
@@ -79,9 +79,6 @@ namespace ValheimPlus.RPC
 
                             Configuration.Current = ConfigurationExtra.LoadFromIni(memStream);
 
-                            // Needed to make sure client is using server configuration as dayLength is setup before
-                            TimeManipulation.SetupDayLength();
-
                             ZLog.Log("Successfully synced VPlus configuration from server.");
                         }
                     }

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -334,7 +334,7 @@ iron=0
 hardWood=0
 
 [Time]
-
+; Enable this section only if you plan all your clients to use V+; if not, then it will not work as expected as the local client w/o V+ totalDayTimeInSeconds won't be adjusted and be out of sync.
 ; Change false to true to enable this section
 enabled=false
 

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -338,8 +338,9 @@ hardWood=0
 ; Change false to true to enable this section
 enabled=false
 
-; Total amount of time one complete day and night circle takes to complete
-totalDayTimeInSeconds=1200
+; Total amount of time in seconds of a full day and night cycle
+; Valheim vanilla days are 21 minutes long, with nights being 9 minutes long. A full loop is 30 minutes (1800 seconds)
+totalDayTimeInSeconds=1800
 
 ; Increase the speed at which time passes at night by %. The value 50 would result in a 50% reduced amount of night time. The value 0 would result in a 0% reduced amount (normal amount).
 nightTimeSpeedMultiplier=0

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -339,7 +339,7 @@ hardWood=0
 enabled=false
 
 ; Total amount of time one complete day and night circle takes to complete
-totalDayTimeInSeconds=1800
+totalDayTimeInSeconds=1200
 
 ; Increase the speed at which time passes at night by %. The value 50 would result in a 50% reduced amount of night time. The value 0 would result in a 0% reduced amount (normal amount).
 nightTimeSpeedMultiplier=0


### PR DESCRIPTION
Hi,

Here the sleep feature refactored:
- Patch as Prefix `EnvMan/RescaleDayFraction` instead of recreating server-side methods for: IsDay, IsAfternoon, IsNight
- Applying daysLength on `EnvMan/FixedUpdate` instead of `EnvMan/Awake`; it avoids resyncing the `m_dayLengthSec` after client been synchronized
- Make config be a full day and night cycle (by assigning `m_dayLengthSec` 2/3 of the value of `totalDayTimeInSeconds`)
- Ensure that if the Time section is disabled `m_dayLengthSec` is assigned to the standard value of Valheim Vanilla

There is one case not covered and needs alignment: 
- Server using V+ with Time section `enabled`
- Server section property `enforceMod` is set to `false`
- Client is not using V+

Result:
- Server will keep boosting the nights
- Client will be out of sync on the phase day time/night time

Cheers,

