### PR TITLE
Update maximumWood configuration to reflect the games default value

### DIFF
--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -289,7 +289,7 @@ capes=0
 enabled=false
 
 ; Maximum amount of wood in a Kiln
-maximumWood=20
+maximumWood=25
 
 ; The time it takes for the Kiln to produce a single piece of coal in seconds.
 productionSpeed=30


### PR DESCRIPTION
The default setting for the Kiln's maximumWood is 25 in the game, but the config file had it set to 20. The setting is correct in the C# config file however:
https://github.com/valheimPlus/ValheimPlus/blob/development/ValheimPlus/Configurations/Sections/KilnConfiguration.cs#L6