### PR TITLE
Fireplace update for clarity in cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ All of these features can be adjusted by a configuration file. This also allows 
 * Modify Workbench radius
 * Modify Ward radius
 
-## Torches and Fireplaces
-* Disable torches running out of fuel
-* Disable fireplaces running out of fuel
+## Fire sources
+* Disable all fire sources from running out of fuel once fuel is added.
+* Disable just torches from running out of fuel once fuel is added.
 
 ## Time and Day Manipulation
 *FEATURE DISABLED DUE TO ISSUES*

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -13,7 +13,7 @@ namespace ValheimPlus.Configurations
         public InventoryConfiguration Inventory { get; set; }
         public ItemsConfiguration Items { get; set; }
         public FermenterConfiguration Fermenter { get; set; }
-        public FireSourceConfiguration FireSources { get; set; }
+        public FireSourceConfiguration FireSource { get; set; }
         public FoodConfiguration Food { get; set; }
         public FurnaceConfiguration Furnace { get; set; }
         public HotkeyConfiguration Hotkeys { get; set; }

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -13,7 +13,7 @@ namespace ValheimPlus.Configurations
         public InventoryConfiguration Inventory { get; set; }
         public ItemsConfiguration Items { get; set; }
         public FermenterConfiguration Fermenter { get; set; }
-        public FireplaceConfiguration Fireplace { get; set; }
+        public FireSourceConfiguration FireSources { get; set; }
         public FoodConfiguration Food { get; set; }
         public FurnaceConfiguration Furnace { get; set; }
         public HotkeyConfiguration Hotkeys { get; set; }

--- a/ValheimPlus/Configurations/Sections/FireSourceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FireSourceConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿namespace ValheimPlus.Configurations.Sections
 {
-    public class FireplaceConfiguration : ServerSyncConfig<FireplaceConfiguration>
+    public class FireSourceConfiguration : ServerSyncConfig<FireSourceConfiguration>
     {
         public bool onlyTorches { get; internal set; } = false;
     }

--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -7,7 +7,7 @@ namespace ValheimPlus
     class FireplaceFuel
     {
         [HarmonyPatch(typeof(Fireplace), "UpdateFireplace")]
-        public static class TorchesNoFuel
+        public static class Fireplace_UpdateFireplace_Patch
         {
             /// <summary>
             /// Prefix which returns false every time to skip the original method and other prefixes so that we're not
@@ -15,7 +15,7 @@ namespace ValheimPlus
             /// </summary>
             private static void Prefix(ref Fireplace __instance)
             {
-                if (!Configuration.Current.Fireplace.IsEnabled) return;
+                if (!Configuration.Current.FireSources.IsEnabled) return;
 
                 if (!__instance.m_nview.IsValid()) return;
 
@@ -41,7 +41,7 @@ namespace ValheimPlus
         internal static void ApplyFuel(ref Fireplace __instance)
         {
             Fireplace localFireplace = __instance;
-            if (Configuration.Current.Fireplace.onlyTorches)
+            if (Configuration.Current.FireSources.onlyTorches)
             {
                 if (torchItemNames.Any(x => x.Equals(localFireplace.m_piece.m_name)))
                 {

--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -1,74 +1,56 @@
 ﻿using HarmonyLib;
+using System.Linq;
 using ValheimPlus.Configurations;
 
-namespace ValheimPlus 
+namespace ValheimPlus
 {
-    class FireplaceFuel 
+    class FireplaceFuel
     {
         [HarmonyPatch(typeof(Fireplace), "UpdateFireplace")]
-        public static class TorchesNoFuel 
+        public static class TorchesNoFuel
         {
             /// <summary>
             /// Prefix which returns false every time to skip the original method and other prefixes so that we're not
             /// needlessly setting fuel value twice
             /// </summary>
-            private static bool Prefix(ref Fireplace __instance, ref ZNetView ___m_nview)
+            private static void Prefix(ref Fireplace __instance)
             {
-                if (!__instance.m_nview.IsValid())
-                    return false; // don't run other prefixes or original
+                if (!Configuration.Current.Fireplace.IsEnabled) return;
+
+                if (!__instance.m_nview.IsValid()) return;
+
                 if (__instance.m_nview.IsOwner())
                 {
-                    if (Configuration.Current.Fireplace.IsEnabled)
-                    {
-                        FireplaceExtension.ApplyFuel(__instance, ref ___m_nview);
-                    }
-                    else
-                    {
-                        // original method
-                        float num1 = __instance.m_nview.GetZDO().GetFloat("fuel");
-                        double timeSinceLastUpdate = __instance.GetTimeSinceLastUpdate();
-                        if (__instance.IsBurning())
-                        {
-                            float num2 = (float)timeSinceLastUpdate / __instance.m_secPerFuel;
-                            float num3 = num1 - num2;
-                            if ((double)num3 <= 0.0)
-                                num3 = 0.0f;
-                            __instance.m_nview.GetZDO().Set("fuel", num3);
-                        }
-                    }
+                    FireplaceExtension.ApplyFuel(ref __instance);
                 }
-                __instance.UpdateState();
-                return false; // don't run other prefixes or original
             }
         }
+    }
 
-        public static class FireplaceExtension
+    public static class FireplaceExtension
+    {
+        static readonly string[] torchItemNames = new[]
         {
-            const string woodTorchName = "$piece_groundtorchwood";
-            const string ironTorchName = "$piece_groundtorch";
-            const string greenTorchName = "$piece_groundtorchgreen";
-            const string sconceName = "$piece_sconce";
-            const string brazierName = "$piece_brazierceiling01";
+            "$piece_groundtorchwood", // standing wood torch
+            "$piece_groundtorch", // standing iron torch
+            "$piece_groundtorchgreen", // standing green torch
+            "$piece_sconce", // sconce torch
+            "$piece_brazierceiling01" // brazier
+        };
 
-            internal static void ApplyFuel(Fireplace __instance, ref ZNetView ___m_nview)
+        internal static void ApplyFuel(ref Fireplace __instance)
+        {
+            Fireplace localFireplace = __instance;
+            if (Configuration.Current.Fireplace.onlyTorches)
             {
-                if (Configuration.Current.Fireplace.onlyTorches)
+                if (torchItemNames.Any(x => x.Equals(localFireplace.m_piece.m_name)))
                 {
-                    if (__instance.m_piece.m_name.Equals(woodTorchName) ||
-                        __instance.m_piece.m_name.Equals(sconceName) ||
-                        __instance.m_piece.m_name.Equals(ironTorchName) ||
-                        __instance.m_piece.m_name.Equals(brazierName) ||
-                        __instance.m_piece.m_name.Equals(greenTorchName))
-                    {
-                        //___m_nview.GetZDO().Set("fuel", __instance.m_maxFuel); // setting to max won't waste rss on fill attempts
-                        ___m_nview.InvokeRPC("AddFuel", new object[] { });
-                    }
+                    __instance.m_nview.GetZDO().Set("fuel", __instance.m_maxFuel); // setting to max won't waste rss on fill attempts
                 }
-                else
-                {
-                    //___m_nview.GetZDO().Set("fuel", __instance.m_maxFuel); // setting to max won't waste rss on fill attempts
-                    ___m_nview.InvokeRPC("AddFuel", new object[] { });
-                }
+            }
+            else
+            {
+                __instance.m_nview.GetZDO().Set("fuel", __instance.m_maxFuel); // setting to max won't waste rss on fill attempts
             }
         }
     }

--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -21,7 +21,9 @@ namespace ValheimPlus
 
                 if (__instance.m_nview.IsOwner())
                 {
-                    FireplaceExtension.ApplyFuel(ref __instance);
+                    if (ZNet.instance == null) return;
+                    ZNet znet = ZNet.instance;
+                    FireplaceExtension.ApplyFuel(ref __instance, ref znet);
                 }
             }
         }
@@ -38,19 +40,22 @@ namespace ValheimPlus
             "$piece_brazierceiling01" // brazier
         };
 
-        internal static void ApplyFuel(ref Fireplace __instance)
+        internal static void ApplyFuel(ref Fireplace __instance, ref ZNet __znet)
         {
             Fireplace localFireplace = __instance;
+
             if (Configuration.Current.FireSource.onlyTorches)
             {
                 if (torchItemNames.Any(x => x.Equals(localFireplace.m_piece.m_name)))
                 {
                     __instance.m_nview.GetZDO().Set("fuel", __instance.m_maxFuel); // setting to max won't waste rss on fill attempts
+                    __instance.m_nview.GetZDO().Set("lastTime", __znet.GetTime().Ticks);
                 }
             }
             else
             {
                 __instance.m_nview.GetZDO().Set("fuel", __instance.m_maxFuel); // setting to max won't waste rss on fill attempts
+                __instance.m_nview.GetZDO().Set("lastTime", __znet.GetTime().Ticks);
             }
         }
     }

--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -15,7 +15,7 @@ namespace ValheimPlus
             /// </summary>
             private static void Prefix(ref Fireplace __instance)
             {
-                if (!Configuration.Current.FireSources.IsEnabled) return;
+                if (!Configuration.Current.FireSource.IsEnabled) return;
 
                 if (!__instance.m_nview.IsValid()) return;
 
@@ -41,7 +41,7 @@ namespace ValheimPlus
         internal static void ApplyFuel(ref Fireplace __instance)
         {
             Fireplace localFireplace = __instance;
-            if (Configuration.Current.FireSources.onlyTorches)
+            if (Configuration.Current.FireSource.onlyTorches)
             {
                 if (torchItemNames.Any(x => x.Equals(localFireplace.m_piece.m_name)))
                 {

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -352,7 +352,7 @@
     <Compile Include="Configurations\Sections\MapConfiguration.cs" />
     <Compile Include="Configurations\Sections\PlayerConfiguration.cs" />
     <Compile Include="Configurations\Sections\ServerConfiguration.cs" />
-    <Compile Include="Configurations\Sections\FireplaceConfiguration.cs" />
+    <Compile Include="Configurations\Sections\FireSourceConfiguration.cs" />
     <Compile Include="Configurations\Sections\TimeConfiguration.cs" />
     <Compile Include="Configurations\Sections\WagonConfiguration.cs" />
     <Compile Include="Configurations\Sections\WardConfiguration.cs" />

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -122,11 +122,11 @@ showFermenterDuration=false
 
 [FireSource]
 
-; If set to true, all fire sources will stay at max fuel level
+; If set to true, all fire sources will stay at max fuel level once filled.
 ; default: false
 enabled=false
 
-; If set to true, only torch-type fire sources will stay at max fuel level. Requires enabled=true above.
+; If set to true, only torch-type fire sources will stay at max fuel level once filled. NOTE: Requires enabled=true above.
 ; Applies to: wood torches, iron torches, green torches, sconces and brazier
 ; default: false
 onlyTorches=false

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -120,13 +120,15 @@ fermenterItemsProduced=6
 ; Display the minutes and seconds until the fermenter is done on hover
 showFermenterDuration=false
 
-[Fireplace]
+[FireSources]
 
-; If changed to enabled all fireplaces do not need to be refilled.
+; If set to true, all fire sources will stay at max fuel level
+; default: false
 enabled=false
 
-; If you enable this option with the previous option to true, only placed torches do not need to be refilled.
-; Apply to: wood torches, iron torches, green torches, sconces and brazier
+; If set to true, only torch-type fire sources will stay at max fuel level. Requires enabled=true.
+; Applies to: wood torches, iron torches, green torches, sconces and brazier
+; default: false
 onlyTorches=false
 
 [Food]

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -126,7 +126,7 @@ showFermenterDuration=false
 ; default: false
 enabled=false
 
-; If set to true, only torch-type fire sources will stay at max fuel level. Requires enabled=true.
+; If set to true, only torch-type fire sources will stay at max fuel level. Requires enabled=true above.
 ; Applies to: wood torches, iron torches, green torches, sconces and brazier
 ; default: false
 onlyTorches=false

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -120,7 +120,7 @@ fermenterItemsProduced=6
 ; Display the minutes and seconds until the fermenter is done on hover
 showFermenterDuration=false
 
-[FireSources]
+[FireSource]
 
 ; If set to true, all fire sources will stay at max fuel level
 ; default: false


### PR DESCRIPTION
- Renamed "Fireplace" to "FireSource" for clarity ("Fireplace" is its name in base game code so some references to "fireplace" in code remain)
- Added clarifying descriptions and defaults in .cfg
- No longer skipping over original method
- Returning to use `m_maxFuel` property instead of `object[]`