### PR TITLE
Addressing cfg "opposite enforceMod" bug

### DIFF
--- a/ValheimPlus/GameClasses/Console.cs
+++ b/ValheimPlus/GameClasses/Console.cs
@@ -1,6 +1,4 @@
-﻿using UnityEngine;
-using HarmonyLib;
-using ValheimPlus.Configurations;
+﻿using HarmonyLib;
 
 namespace ValheimPlus
 {
@@ -10,7 +8,7 @@ namespace ValheimPlus
         /// Adding version data to console
         /// </summary>
         [HarmonyPatch(typeof(Console), "Awake")]
-        public static class HookConsole
+        public static class Console_Awake_Patch
         {
             private static void Postfix(ref Console __instance)
             {
@@ -26,30 +24,6 @@ namespace ValheimPlus
                 }
 
                 __instance.AddString("");
-            }
-        }
-
-        [HarmonyPatch(typeof(Version), "GetVersionString")]
-        public static class VersionServerControl
-        {
-            private static bool Prefix(ref string __result)
-            {
-                string gameVersion = Version.CombineVersion(global::Version.m_major, global::Version.m_minor, global::Version.m_patch);
-                __result = gameVersion;
-
-                Debug.Log($"Version generator started.");
-                if (Configuration.Current.Server.IsEnabled)
-                {
-                    if (Configuration.Current.Server.enforceMod)
-                    {
-                        Debug.Log($"Version generated with enforced mod : {__result}");
-                        __result = gameVersion + "@" + ValheimPlusPlugin.version;
-                        return false;
-                    }
-                }
-
-                Debug.Log($"Version generated : {__result}");
-                return false;
             }
         }
     }

--- a/ValheimPlus/GameClasses/Version.cs
+++ b/ValheimPlus/GameClasses/Version.cs
@@ -10,26 +10,23 @@ namespace ValheimPlus
         /// Get version string and enforce mod if enabled
         /// </summary>
         [HarmonyPatch(typeof(Version), "GetVersionString")]
-        public static class VersionServerControl
+        public static class Version_GetVersionString_Patch
         {
-            private static bool Prefix(ref string __result)
+            private static void Postfix(ref string __result)
             {
-                string gameVersion = Version.CombineVersion(global::Version.m_major, global::Version.m_minor, global::Version.m_patch);
-                __result = gameVersion;
-
                 Debug.Log($"Version generator started.");
                 if (Configuration.Current.Server.IsEnabled)
                 {
                     if (Configuration.Current.Server.enforceMod)
                     {
-                        __result = gameVersion + "@" + ValheimPlusPlugin.version;
+                        __result = __result + "@" + ValheimPlusPlugin.version;
                         Debug.Log($"Version generated with enforced mod : {__result}");
-                        return false;
                     }
                 }
-
-                Debug.Log($"Version generated : {__result}");
-                return false;
+                else
+                {
+                    Debug.Log($"Version generated : {__result}");
+                }
             }
         }
     }

--- a/ValheimPlus/RPC/VPlusConfigSync.cs
+++ b/ValheimPlus/RPC/VPlusConfigSync.cs
@@ -11,7 +11,7 @@ namespace ValheimPlus.RPC
         {
             if (ZNet.m_isServer) //Server
             {
-                if (!Configuration.Current.Server.serverSyncsConfig) return;
+                if (!Configuration.Current.Server.IsEnabled || !Configuration.Current.Server.serverSyncsConfig) return;
 
                 ZPackage pkg = new ZPackage();
 


### PR DESCRIPTION
Found a duplicate version string check and moved version string patch to use Postfix instead of Prefix