### PR TITLE
Properly apply radius increases of the CraftingStation and Ward to th…

### DIFF
--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -15,6 +15,7 @@ namespace ValheimPlus.Configurations
         public FermenterConfiguration Fermenter { get; set; }
         public FireSourceConfiguration FireSource { get; set; }
         public FoodConfiguration Food { get; set; }
+        public SmelterConfiguration Smelter { get; set; }
         public FurnaceConfiguration Furnace { get; set; }
         public HotkeyConfiguration Hotkeys { get; set; }
         public KilnConfiguration Kiln { get; set; }

--- a/ValheimPlus/Configurations/Sections/SmelterConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/SmelterConfiguration.cs
@@ -1,0 +1,13 @@
+﻿namespace ValheimPlus.Configurations.Sections
+{
+    public class SmelterConfiguration : ServerSyncConfig<SmelterConfiguration>
+    {
+        public int maximumOre { get; set; } = 10;
+        public int maximumCoal { get; set; } = 20;
+        public int coalUsedPerProduct { get; set; } = 2;
+        public float productionSpeed { get; set; } = 30;
+        public bool autoDeposit { get; set; } = false;
+        public float autoDepositRange { get; set; } = 10;
+    }
+
+}

--- a/ValheimPlus/GameClasses/CraftingStation.cs
+++ b/ValheimPlus/GameClasses/CraftingStation.cs
@@ -12,7 +12,7 @@ namespace ValheimPlus
         [HarmonyPatch(typeof(CraftingStation), "Start")]
         public static class WorkbenchRangeIncrease
         {
-            private static void Prefix(ref float ___m_rangeBuild, GameObject ___m_areaMarker)
+            private static void Prefix(CraftingStation __instance, ref float ___m_rangeBuild, GameObject ___m_areaMarker)
             {
                 if (Configuration.Current.Workbench.IsEnabled && Configuration.Current.Workbench.workbenchRange > 0) 
                 {
@@ -22,6 +22,10 @@ namespace ValheimPlus
                         ___m_areaMarker.GetComponent<CircleProjector>().m_radius = ___m_rangeBuild;
                         float scaleIncrease = (Configuration.Current.Workbench.workbenchRange - 20f) / 20f * 100f;
                         ___m_areaMarker.gameObject.transform.localScale = new Vector3(scaleIncrease / 100, 1f, scaleIncrease / 100);
+
+                        // Apply this change to the child GameObject's EffectArea collision.
+                        // Various other systems query this collision instead of the PrivateArea radius for permissions (notably, enemy spawning).
+                        Helper.ResizeChildEffectArea(__instance, EffectArea.Type.PlayerBase, Configuration.Current.Workbench.workbenchRange);
                     }
                     catch
                     {

--- a/ValheimPlus/GameClasses/Smelter.cs
+++ b/ValheimPlus/GameClasses/Smelter.cs
@@ -21,6 +21,16 @@ namespace ValheimPlus
                     __instance.m_secPerProduct = Configuration.Current.Kiln.productionSpeed;
                 }
             }
+            else if (__instance.m_name.Equals(SmelterDefinitions.SmelterName))
+            {
+                if (Configuration.Current.Smelter.IsEnabled)
+                {
+                    __instance.m_maxOre = Configuration.Current.Smelter.maximumOre;
+                    __instance.m_maxFuel = Configuration.Current.Smelter.maximumCoal;
+                    __instance.m_secPerProduct = Configuration.Current.Smelter.productionSpeed;
+                    __instance.m_fuelPerProduct = Configuration.Current.Smelter.coalUsedPerProduct;
+                }
+            }
             else if (__instance.m_name.Equals(SmelterDefinitions.FurnaceName))
             {
                 if (Configuration.Current.Furnace.IsEnabled)
@@ -49,6 +59,17 @@ namespace ValheimPlus
                     if (Configuration.Current.Kiln.autoDeposit)
                     {
                         bool result = spawn(Configuration.Current.Kiln.autoDepositRange);
+                        return result;
+                    }
+                }
+            }
+            else if (__instance.m_name.Equals(SmelterDefinitions.SmelterName))
+            {
+                if (Configuration.Current.Smelter.IsEnabled)
+                {
+                    if (Configuration.Current.Smelter.autoDeposit)
+                    {
+                        bool result = spawn(Configuration.Current.Smelter.autoDepositRange);
                         return result;
                     }
                 }
@@ -119,6 +140,7 @@ namespace ValheimPlus
     public static class SmelterDefinitions
     {
         public static readonly string KilnName = "$piece_charcoalkiln";
+        public static readonly string SmelterName = "$piece_smelter";
         public static readonly string FurnaceName = "$piece_blastfurnace";
     }
 }

--- a/ValheimPlus/GameClasses/Ward.cs
+++ b/ValheimPlus/GameClasses/Ward.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using UnityEngine;
 using ValheimPlus.Configurations;
 
 namespace ValheimPlus
@@ -15,7 +16,11 @@ namespace ValheimPlus
             {
                 if (Configuration.Current.Ward.IsEnabled && Configuration.Current.Ward.wardRange > 0) 
                 {
-                   __instance.m_radius  = Configuration.Current.Ward.wardRange;
+                    __instance.m_radius  = Configuration.Current.Ward.wardRange;
+
+                    // Apply this change to the child GameObject's EffectArea collision.
+                    // Various other systems query this collision instead of the PrivateArea radius for permissions (notably, enemy spawning).
+                    Helper.ResizeChildEffectArea(__instance, EffectArea.Type.PlayerBase, Configuration.Current.Ward.wardRange);
                 }
             }
         }

--- a/ValheimPlus/Utility/Helper.cs
+++ b/ValheimPlus/Utility/Helper.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 namespace ValheimPlus
 {
@@ -36,6 +37,26 @@ namespace ValheimPlus
             }
 
             return newValue;
+        }
+
+        // Resize child EffectArea's collision that matches the specified type(s).
+        public static void ResizeChildEffectArea(MonoBehaviour parent, EffectArea.Type includedTypes, float newRadius)
+        {
+            if (parent != null)
+            {
+                EffectArea effectArea = parent.GetComponentInChildren<EffectArea>();
+                if (effectArea != null)
+                {
+                    if ((effectArea.m_type & includedTypes) != 0)
+                    {
+                        SphereCollider collision = effectArea.GetComponent<SphereCollider>();
+                        if (collision != null)
+                        {
+                            collision.radius = newRadius;
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -333,6 +333,7 @@
     <Compile Include="Configurations\Sections\ArmorConfiguration.cs" />
     <Compile Include="Configurations\Sections\DurabilityConfiguration.cs" />
     <Compile Include="Configurations\Sections\GatherConfiguration.cs" />
+    <Compile Include="Configurations\Sections\SmelterConfiguration.cs" />
     <Compile Include="GameClasses\Beehive.cs" />
     <Compile Include="Configurations\BaseConfig.cs" />
     <Compile Include="Configurations\Configuration.cs" />

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -140,6 +140,29 @@ enabled=false
 ; Allows for - values to shorten food duration.
 foodDurationMultiplier=0
 
+[Smelter]
+
+; Change false to true to enable this section
+enabled=false
+
+; Maximum amount of ore in a smelter
+maximumOre=10
+
+; Maximum amount of coal in a smelter
+maximumCoal=20
+
+; The total amount of coal used to produce a single smelted ingot.
+coalUsedPerProduct=2
+
+; The time it takes for the smelter to produce a single ingot in seconds.
+productionSpeed=30
+
+; Instead of dropping the items, they will be placed inside nearby chests instead.
+autoDeposit=false
+
+; The range of the chest detection for the auto deposit feature. (Maximum is 50)
+autoDepositRange=10
+
 [Furnace]
 
 ; Change false to true to enable this section


### PR DESCRIPTION
…eir EffectArea.

CraftingStation and Wards have a child GameObject that has an EffectArea and a collider. The mob spawning system uses this collision to check whether spawning is allowed, and the collision radius is not automatically updated with the CraftingStation/Ward radii. So, without this, mobs can still spawn inside those expanded areas. By adjusting the EffectArea as well, we can ensure that any modification to the ranges there apply to mob spawning as well.