### PR TITLE
Properly apply radius increases of the CraftingStation and Ward to their EffectArea

### DIFF
--- a/ValheimPlus/GameClasses/CraftingStation.cs
+++ b/ValheimPlus/GameClasses/CraftingStation.cs
@@ -12,7 +12,7 @@ namespace ValheimPlus
         [HarmonyPatch(typeof(CraftingStation), "Start")]
         public static class WorkbenchRangeIncrease
         {
-            private static void Prefix(ref float ___m_rangeBuild, GameObject ___m_areaMarker)
+            private static void Prefix(CraftingStation __instance, ref float ___m_rangeBuild, GameObject ___m_areaMarker)
             {
                 if (Configuration.Current.Workbench.IsEnabled && Configuration.Current.Workbench.workbenchRange > 0) 
                 {
@@ -22,6 +22,10 @@ namespace ValheimPlus
                         ___m_areaMarker.GetComponent<CircleProjector>().m_radius = ___m_rangeBuild;
                         float scaleIncrease = (Configuration.Current.Workbench.workbenchRange - 20f) / 20f * 100f;
                         ___m_areaMarker.gameObject.transform.localScale = new Vector3(scaleIncrease / 100, 1f, scaleIncrease / 100);
+
+                        // Apply this change to the child GameObject's EffectArea collision.
+                        // Various other systems query this collision instead of the PrivateArea radius for permissions (notably, enemy spawning).
+                        Helper.ResizeChildEffectArea(__instance, EffectArea.Type.PlayerBase, Configuration.Current.Workbench.workbenchRange);
                     }
                     catch
                     {

--- a/ValheimPlus/GameClasses/Ward.cs
+++ b/ValheimPlus/GameClasses/Ward.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using UnityEngine;
 using ValheimPlus.Configurations;
 
 namespace ValheimPlus
@@ -15,7 +16,11 @@ namespace ValheimPlus
             {
                 if (Configuration.Current.Ward.IsEnabled && Configuration.Current.Ward.wardRange > 0) 
                 {
-                   __instance.m_radius  = Configuration.Current.Ward.wardRange;
+                    __instance.m_radius = Configuration.Current.Ward.wardRange;
+
+                    // Apply this change to the child GameObject's EffectArea collision.
+                    // Various other systems query this collision instead of the PrivateArea radius for permissions (notably, enemy spawning).
+                    Helper.ResizeChildEffectArea(__instance, EffectArea.Type.PlayerBase, Configuration.Current.Ward.wardRange);
                 }
             }
         }

--- a/ValheimPlus/Utility/Helper.cs
+++ b/ValheimPlus/Utility/Helper.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 namespace ValheimPlus
 {
@@ -36,6 +37,26 @@ namespace ValheimPlus
             }
 
             return newValue;
+        }
+
+        // Resize child EffectArea's collision that matches the specified type(s).
+        public static void ResizeChildEffectArea(MonoBehaviour parent, EffectArea.Type includedTypes, float newRadius)
+        {
+            if (parent != null)
+            {
+                EffectArea effectArea = parent.GetComponentInChildren<EffectArea>();
+                if (effectArea != null)
+                {
+                    if ((effectArea.m_type & includedTypes) != 0)
+                    {
+                        SphereCollider collision = effectArea.GetComponent<SphereCollider>();
+                        if (collision != null)
+                        {
+                            collision.radius = newRadius;
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
CraftingStation and Wards have a child GameObject that has an EffectArea and a collider. The mob spawning system uses this collision to check whether spawning is allowed, and the collision radius is not automatically updated with the CraftingStation/Ward radii. So, without this, mobs can still spawn inside those expanded areas. By adjusting the EffectArea as well, we can ensure that any modification to the ranges there apply to mob spawning as well.