### PR TITLE
Revert "Add the ability to remember the mouse position when it loses focus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ All of these features can be adjusted by a configuration file. This also allows 
 * Modify your inventory sizes of player inventory, chests, boats and else.
 * Disable the red flash on screen when damage is received
 * Display a warning message when you try to place crops to close to another crop
-* Remember mouse position when it loses focus (Windows only)
 
 ## Inventory
 * Modify the amount of rows and columns in each inventory of the game

--- a/ValheimPlus/Configurations/Sections/HudConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/HudConfiguration.cs
@@ -7,6 +7,5 @@
         public float chatMessageDistance { get; internal set; }
         public bool displayStaminaValue { get; internal set; } = false;
         public bool removeDamageFlash { get; internal set; } = false;
-        public bool rememberMousePosition { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/GameCamera.cs
+++ b/ValheimPlus/GameClasses/GameCamera.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using HarmonyLib;
-using UnityEngine;
+﻿using HarmonyLib;
 using ValheimPlus.Configurations;
 
 namespace ValheimPlus.GameClasses
@@ -37,66 +35,6 @@ namespace ValheimPlus.GameClasses
                     __instance.m_minDistance = 1;
                 }
             }
-        }
-    }
-
-    [HarmonyPatch(typeof(GameCamera), nameof(GameCamera.UpdateMouseCapture))]
-    public static class GameCamera_UpdateMouseCapture_RememberMousePosition
-    {
-        private static Vector2 savedMousePosition;
-
-        private static void Prefix(out State __state)
-        {
-            __state = new State()
-            {
-                PreviousLockState = Cursor.lockState,
-                CurrentMousePosition = new Vector2(Input.mousePosition.x, Screen.height - Input.mousePosition.y - 1)
-            };
-        }
-
-        private static void Postfix(State __state)
-        {
-            if (!(Configuration.Current.Hud.IsEnabled && Configuration.Current.Hud.rememberMousePosition))
-            {
-                return;
-            }
-
-            var currentLockState = Cursor.lockState;
-
-            if (__state.PreviousLockState == currentLockState)
-            {
-                return;
-            }
-
-            if (__state.PreviousLockState == CursorLockMode.None && currentLockState == CursorLockMode.Locked)
-            {
-                savedMousePosition = __state.CurrentMousePosition;
-            }
-
-            if (__state.PreviousLockState == CursorLockMode.Locked)
-            {
-                if (Application.platform == RuntimePlatform.WindowsPlayer)
-                {
-                    User32.SetCursorPosition(savedMousePosition);
-                }
-            }
-        }
-
-        public class State
-        {
-            public CursorLockMode PreviousLockState { get; set; }
-            public Vector2 CurrentMousePosition { get; set; }
-        }
-
-        private static class User32
-        {
-            public static void SetCursorPosition(Vector2 position)
-            {
-                SetCursorPos((int)position.x, (int)position.y);
-            }
-
-            [DllImport("user32.dll")]
-            private static extern bool SetCursorPos(int X, int Y);
         }
     }
 }

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -292,9 +292,6 @@ displayStaminaValue=false
 ; Set to true to remove the red screen flash overlay when the player takes damage.
 removeDamageFlash=false
 
-; Prevents the mouse cursor from being recentered every time it loses focus (Windows only)
-rememberMousePosition=false
-
 [Gathering]
 
 ; Change false to true to enable this section


### PR DESCRIPTION
This one is bizarre - #248 appears to have introduced an odd crash with the following call stack on Linux. (tested: Debian and Ubuntu, headless). This was discovered via `git bisect`.

```
03/10/2021 21:31:26: DungeonDB Start 344

(Filename: ./Runtime/Export/Debug/Debug.bindings.h Line: 35)

Caught fatal signal - signo:11 code:1 errno:0 addr:0x7ffdc9fa6431
Obtained 15 stack frames.
#0  0x007f3aa7b30730 in funlockfile
#1  0x0000004175c0af in (Unknown)
#2  0x007f3aa7222715 in mono_print_method_from_ip
#3  0x007f3aa73921cc in mono_perfcounter_foreach
#4  0x007f3aa7393079 in mono_runtime_invoke
#5  0x007f3aa86e8c82 in scripting_method_invoke(ScriptingMethodPtr, ScriptingObjectPtr, ScriptingArguments&, ScriptingExceptionPtr*, bool)
#6  0x007f3aa86e703a in ScriptingInvocation::Invoke(ScriptingExceptionPtr*, bool)
#7  0x007f3aa86cd0e7 in MonoBehaviour::CallUpdateMethod(int)
#8  0x007f3aa8473bad in void BaseBehaviourManager::CommonUpdate<LateBehaviourManager>()
#9  0x007f3aa85d535e in ExecutePlayerLoop(NativePlayerLoopSystem*)
#10 0x007f3aa85d53a1 in ExecutePlayerLoop(NativePlayerLoopSystem*)
#11 0x007f3aa85d58da in PlayerLoop()
#12 0x007f3aa873f6ae in PlayerMain(int, char**)
#13 0x007f3aa797f09b in __libc_start_main
#14 0x00564921b16699 in _start
Aborted
```

At first glance, it would appear that the import of `user32.dll` would be the culprit. However, after binary chopping this code to pieces, it appears that *any* usage of the Harmony hooks in this function will cause the crash, even the following minimal repro.

```cs
[HarmonyPatch(typeof(GameCamera), nameof(GameCamera.UpdateMouseCapture))]
public static class GameCamera_UpdateMouseCapture_RememberMousePosition
{
    [HarmonyPrefix]
    private static void Prefix()
    {
    }

    [HarmonyPostfix]
    private static void Postfix()
    {
    }
}
```

`GameCamera::UpdateMouseCapture` calls various cursor-lock-related functionality - the working theory is that perhaps internally, Unity throws and handles exceptions when accessing these things when headless, and the introduction of Harmony hooks causes these exceptions to be treated differently and results in a magnificently catastrophic crash.

This one is quite odd, and I would encourage readers to experiment with changing these hooks and observing the various ways in which the game crashes on headless Linux servers. With advanced low-level knowledge about how to debug run-time manipulated CIL, this could be an interesting problem to dig into.

For the purposes of the next release, I recommend reverting this change (as this PR does) so it doesn't block everything.