### PR TITLE
Fixing deconstruct button persistence

### DIFF
--- a/ValheimPlus/Deconstruct.cs
+++ b/ValheimPlus/Deconstruct.cs
@@ -13,7 +13,6 @@ namespace ValheimPlus
     {
         public static InventoryGui __inventoryGui;
         public static Button m_tabDeconstruct;
-        public static Button m_deconstructButton;
         private const string deconstructText = "Deconstruct";
         private static Recipe m_deconstructRecipe;
         private static ItemDrop.ItemData m_deconstructItem;
@@ -47,13 +46,6 @@ namespace ValheimPlus
             RectTransform tabWidth = (RectTransform)Deconstruct.__inventoryGui.m_tabUpgrade.transform;
             m_tabDeconstruct.transform.position += new Vector3(6f + tabWidth.rect.width, 0, 0);
             m_tabDeconstruct.onClick.AddListener(OnTabDeconstructPressed);
-
-            // set up deconstruct button
-            m_deconstructButton = Object.Instantiate<Button>(Deconstruct.__inventoryGui.m_craftButton);
-            m_deconstructButton.GetComponentInChildren<Text>().text = deconstructText; // needs localization
-            m_deconstructButton.gameObject.SetActive(false);
-            m_deconstructButton.transform.SetParent(Deconstruct.__inventoryGui.m_craftButton.transform.parent, false);
-            m_deconstructButton.onClick.AddListener(new UnityAction(OnDeconstructPressed));
         }
 
         public static void Deconstruct_UpdateRecipeList(ref Player __player)
@@ -197,9 +189,9 @@ namespace ValheimPlus
                 bool craftingStationIsValid = !requiredStation || (currentCraftingStation && currentCraftingStation.CheckUsable(__localPlayer, false));
 
                 // should deconstruct button be clickable
-                m_deconstructButton.interactable = (((playerHasRequirements && craftingStationIsValid) || __localPlayer.NoCostCheat()) && playerHasInventorySpace);
-                m_deconstructButton.GetComponentInChildren<Text>().text = deconstructText;
-                UITooltip component = m_deconstructButton.GetComponent<UITooltip>();
+                __inventoryGui.m_craftButton.interactable = (((playerHasRequirements && craftingStationIsValid) || __localPlayer.NoCostCheat()) && playerHasInventorySpace);
+                __inventoryGui.m_craftButton.GetComponentInChildren<Text>().text = deconstructText;
+                UITooltip component = __inventoryGui.m_craftButton.GetComponent<UITooltip>();
 
                 if (!playerHasInventorySpace)
                 {
@@ -225,7 +217,7 @@ namespace ValheimPlus
                 __inventoryGui.m_recipeDecription.enabled = false;
                 __inventoryGui.m_qualityPanel.gameObject.SetActive(false);
                 __inventoryGui.m_minStationLevelIcon.gameObject.SetActive(false);
-                m_deconstructButton.GetComponent<UITooltip>().m_text = "";
+                __inventoryGui.m_craftButton.GetComponent<UITooltip>().m_text = "";
                 __inventoryGui.m_variantButton.gameObject.SetActive(false);
                 __inventoryGui.m_itemCraftType.gameObject.SetActive(false);
 
@@ -234,18 +226,18 @@ namespace ValheimPlus
                     InventoryGui.HideRequirement(__inventoryGui.m_recipeRequirementList[index].transform);
                 }
 
-                m_deconstructButton.interactable = false;
+                __inventoryGui.m_craftButton.interactable = false;
             }
 
             // if deconstruct button has not been pressed
             if ((double)__inventoryGui.m_craftTimer < 0.0)
             {
                 __inventoryGui.m_craftProgressPanel.gameObject.SetActive(false);
-                m_deconstructButton.gameObject.SetActive(true);
+                __inventoryGui.m_craftButton.gameObject.SetActive(true);
             }
             else
             {
-                m_deconstructButton.gameObject.SetActive(false);
+                __inventoryGui.m_craftButton.gameObject.SetActive(false);
                 __inventoryGui.m_craftProgressPanel.gameObject.SetActive(true);
                 __inventoryGui.m_craftProgressPanel.GetComponentInChildren<Text>().text = "Deconstructing...";
                 __inventoryGui.m_craftProgressBar.SetMaxValue(__inventoryGui.m_craftDuration);
@@ -499,7 +491,7 @@ namespace ValheimPlus
             return (amountToReturn * multiplier) / 100;
         }
 
-        private static void OnDeconstructPressed()
+        public static void OnDeconstructPressed()
         {
             if (__inventoryGui.m_selectedRecipe.Key == null) return;
 

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -11,8 +11,8 @@ using ValheimPlus.Configurations;
 namespace ValheimPlus.GameClasses
 {
 	
-	[HarmonyPatch(typeof(InventoryGui), "Show")]
-	public class InventoryGUI_Show_Patch 
+	[HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.Show))]
+	public class InventoryGui_Show_Patch 
 	{
 		private const float oneRowSize = 70.5f;
 		private const float containerOriginalY = -90.0f;
@@ -137,7 +137,7 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Setting up deconstruct feature
     /// </summary>
-    [HarmonyPatch(typeof(InventoryGui), "Awake")]
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.Awake))]
     public static class InventoryGui_Awake_Patch
     {
         private static void Postfix(ref InventoryGui __instance)
@@ -152,7 +152,7 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Setting deconstruct tab state on update crafting panel
     /// </summary>
-    [HarmonyPatch(typeof(InventoryGui), "UpdateCraftingPanel")]
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.UpdateCraftingPanel))]
     public static class InventoryGui_UpdateCraftingPanel_Patch
     {
         private static void Postfix(ref InventoryGui __instance)
@@ -180,7 +180,7 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Updating recipe list for deconstruct if deconstruct is enabled
     /// </summary>
-    [HarmonyPatch(typeof(InventoryGui), "UpdateRecipeList")]
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.UpdateRecipeList))]
     public static class InventoryGui_UpdateRecipeList_Patch
     {
         private static bool Prefix(ref InventoryGui __instance, List<Recipe> recipes)
@@ -204,7 +204,7 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Updating recipe for deconstruct if deconstruct is enabled
     /// </summary>
-    [HarmonyPatch(typeof(InventoryGui), "UpdateRecipe")]
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.UpdateRecipe))]
     public static class InventoryGui_UpdateRecipe_Patch
     {
         private static bool Prefix(ref InventoryGui __instance)
@@ -228,7 +228,28 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Accounting for deconstruct tab in craft tab press
     /// </summary>
-    [HarmonyPatch(typeof(InventoryGui), "OnTabCraftPressed")]
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.OnCraftPressed))]
+    public static class InventoryGui_OnCraftPressed_Patch
+    {
+        private static bool Prefix(ref InventoryGui __instance)
+        {
+            if (Configuration.Current.Deconstruct.IsEnabled)
+            {
+                if (Deconstruct.InDeconstructTab())
+                {
+                    Deconstruct.OnDeconstructPressed();
+                    return false; // skipping original so that we only run deconstruct button function
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Accounting for deconstruct tab in craft tab press
+    /// </summary>
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.OnTabCraftPressed))]
     public static class InventoryGui_OnTabCraftPressed_Patch
     {
         private static void Prefix(ref InventoryGui __instance)
@@ -236,7 +257,6 @@ namespace ValheimPlus.GameClasses
             if (Configuration.Current.Deconstruct.IsEnabled)
             {
                 Deconstruct.SetDeconstructTab(true);
-                Deconstruct.m_deconstructButton.gameObject.SetActive(false);
             }
         }
     }
@@ -244,7 +264,7 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Accounting for deconstruct tab in upgrade tab press
     /// </summary>
-    [HarmonyPatch(typeof(InventoryGui), "OnTabUpgradePressed")]
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.OnTabUpgradePressed))]
     public static class InventoryGui_OnTabUpgradePressed_Patch
     {
         private static void Prefix(ref InventoryGui __instance)
@@ -252,7 +272,6 @@ namespace ValheimPlus.GameClasses
             if (Configuration.Current.Deconstruct.IsEnabled)
             {
                 Deconstruct.SetDeconstructTab(true);
-                Deconstruct.m_deconstructButton.gameObject.SetActive(false);
             }
         }
     }
@@ -260,7 +279,7 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Inventory HUD setup
     /// </summary>
-    [HarmonyPatch(typeof(InventoryGui), "SetupRequirement")]
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.SetupRequirement))]
     public static class InventoryGui_SetupRequirement_Patch
     {
         private static bool Prefix(Transform elementRoot, Piece.Requirement req, Player player, bool craft, int quality, ref bool __result)


### PR DESCRIPTION
Removed newly created deconstruct button and overriding OnCraftPressed and updating current crafing button instead. Updates to patch names for convention