### PR TITLE
Structural integrity bug fix

### DIFF
--- a/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
@@ -8,5 +8,6 @@
         public float hardWood { get; internal set; } = 0;
         public bool disableStructuralIntegrity { get; set; } = false;
         public bool disableDamageToPlayerStructures { get; set; } = false;
+        public bool disableDamageToPlayerBoats { get; set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/WearNTear.cs
+++ b/ValheimPlus/GameClasses/WearNTear.cs
@@ -39,13 +39,20 @@ namespace ValheimPlus.GameClasses
 	[HarmonyPatch(typeof(WearNTear), "ApplyDamage")]
 	public static class WearNTear_ApplyDamage_Patch
 	{
-		private static bool Prefix(ref WearNTear __instance,ref float damage)
-		{
-			if (Configuration.Current.StructuralIntegrity.IsEnabled && Configuration.Current.StructuralIntegrity.disableDamageToPlayerStructures && __instance.m_piece && __instance.m_piece.IsPlacedByPlayer())
-				return false;
+        private static bool Prefix(ref WearNTear __instance, ref float damage)
+        {
+            // Gets the name of the method calling the ApplyDamage method
+            StackTrace stackTrace = new StackTrace();
+            string callingMethod = stackTrace.GetFrame(2).GetMethod().Name;
 
-			return true;
-		}
+            if (!(Configuration.Current.StructuralIntegrity.IsEnabled && __instance.m_piece && __instance.m_piece.IsPlacedByPlayer() && callingMethod != "UpdateWear"))
+                return true;
+
+            if (__instance.m_piece.m_name.StartsWith("$ship"))
+                return !Configuration.Current.StructuralIntegrity.disableDamageToPlayerBoats;
+
+            return !Configuration.Current.StructuralIntegrity.disableDamageToPlayerStructures;
+        }
 	}
 
 	/// <summary>

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -494,8 +494,11 @@ enabled=false
 ; Disables the entire structural integrity system and allows for placement in free air, does not prevent building damage.
 disableStructuralIntegrity=false
 
-; Disables any damage from anything to all player built structures
+; Disables any damage from anything to all player built structures. Does not prevent damage from structural integrity.
 disableDamageToPlayerStructures=false
+
+; Disables any damage from anything to all player built boats
+disableDamageToPlayerBoats=false
 
 ; Each of these values reduce the loss of structural integrity by % less. The value 100 would result in disabled structural integrity and allow placement in free air.
 wood=0


### PR DESCRIPTION
Fixes an issue described in #299. This does not yet implement checks to see what is inflicting damage to the structure or boat.

Separates damage from structural integrity and damage to boats from disableDamageToPlayerStructures. Adds a new config entry for disabling damage to boats - disableDamageToPlayerBoats.