### PR TITLE
Camera FOV standard settings

### DIFF
--- a/ValheimPlus/Configurations/Sections/CameraConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/CameraConfiguration.cs
@@ -4,6 +4,6 @@
     {
         public float cameraMaximumZoomDistance { get; internal set; } = 1146;
         public float cameraBoatMaximumZoomDistance { get; internal set; } = 6;
-        public float cameraFOV { get; internal set; } = 85;
+        public float cameraFOV { get; internal set; } = 65;
     }
 }


### PR DESCRIPTION
According to the config-files and the settings for first-person view the standard FOV setting should be 65 and not 85, proposing to change this here as well to reflect this.