### PR TITLE
MegingjordBuff fix

### DIFF
--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -146,8 +146,9 @@ namespace ValheimPlus.GameClasses
                 if (statusEffect.m_name.Contains("beltstrength"))
                 {
                     limit = baseLimit + Configuration.Current.Player.baseMegingjordBuff;
+                    statusEffect.ModifyMaxCarryWeight(baseLimit, ref limit);
                 }
-                statusEffect.ModifyMaxCarryWeight(baseLimit, ref limit);
+
             }
 
             return false;


### PR DESCRIPTION
Currently, se.ModifyMaxCarryWeight() can be called more than

With this quick fix, even if "beltstrength" is not an unique statusEffect, the weight should only be modified once.

-Mist