### PR TITLE
Karve inventory minimums and defaults incorrect (issue #372)

### DIFF
--- a/ValheimPlus/GameClasses/Container.cs
+++ b/ValheimPlus/GameClasses/Container.cs
@@ -22,9 +22,9 @@ namespace ValheimPlus
         private const int ironChestInventoryMinCol = 6;
 
         private const int karveChestInventoryMaxRows = 30;
-        private const int karveChestInventoryMinRows = 3;
+        private const int karveChestInventoryMinRows = 2;
         private const int karveChestInventoryMaxCol = 8;
-        private const int karveChestInventoryMinCol = 6;
+        private const int karveChestInventoryMinCol = 2;
 
         private const int longboatChestInventoryMaxRows = 30;
         private const int longboatChestInventoryMinRows = 3;

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -593,12 +593,12 @@ cartInventoryColumns=8
 cartInventoryRows=3
 
 ; Karve (small boat) inventory number of columns
-; default 8, min 6, max 8
-karveInventoryColumns=8
+; default 2, min 2, max 8
+karveInventoryColumns=2
 
 ; Karve (small boat) inventory number of rows (more than 4 rows will add a scrollbar)
-; default 3, min 3, max 30
-karveInventoryRows=3
+; default 2, min 2, max 30
+karveInventoryRows=2
 
 ; Longboat (large boat) inventory number of columns
 ; default 8, min 6, max 8


### PR DESCRIPTION
Issue #372 points out that the default inventory size is larger than the game default.

I've adjusted the values for `karveInventoryColumns` and `karveInventoryRows` as well as the commented defaults, to the game defaults, in valheim_plus.cfg.
This puts those values under the minimums set in ValheimPlus/GameClasses/Container.cs, so I've also adjusted those, as well as the minimums commented in valheim_plus.cfg.