### PR TITLE
Updating start_server_bepinex.sh for 0.9.5.5 fix

### DIFF
--- a/resources/unix/start_server_bepinex.sh
+++ b/resources/unix/start_server_bepinex.sh
@@ -24,14 +24,18 @@ server_public=1
 
 # The rest is automatically handled by BepInEx for Valheim+
 
+# Set base path of start_server_bepinex.sh location
+export VALHEIM_PLUS_SCRIPT=$(readlink -f "$0")
+export VALHEIM_PLUS_PATH=$(dirname "$VALHEIM_PLUS_SCRIPT")
+
 # Whether or not to enable Doorstop. Valid values: TRUE or FALSE
 export DOORSTOP_ENABLE=TRUE
 
 # What .NET assembly to execute. Valid value is a path to a .NET DLL that mono can execute.
-export DOORSTOP_INVOKE_DLL_PATH="${PWD}/BepInEx/core/BepInEx.Preloader.dll"
+export DOORSTOP_INVOKE_DLL_PATH="${VALHEIM_PLUS_PATH}/BepInEx/core/BepInEx.Preloader.dll"
 
 # Which folder should be put in front of the Unity dll loading path
-export DOORSTOP_CORLIB_OVERRIDE_PATH=./unstripped_corlib
+export DOORSTOP_CORLIB_OVERRIDE_PATH="${VALHEIM_PLUS_PATH}/unstripped_corlib"
 
 # ----- DO NOT EDIT FROM THIS LINE FORWARD  ------
 # ----- (unless you know what you're doing) ------
@@ -41,21 +45,21 @@ if [ ! -x "$1" -a ! -x "$executable_name" ]; then
 	exit 1
 fi
 
-doorstop_libs="${PWD}/doorstop_libs"
+doorstop_libs="${VALHEIM_PLUS_PATH}/doorstop_libs"
 arch=""
 executable_path=""
 lib_postfix=""
 
-os_type=`uname -s`
+os_type=$(uname -s)
 case $os_type in
 	Linux*)
-		executable_path="${PWD}/${executable_name}"
+		executable_path="${VALHEIM_PLUS_PATH}/${executable_name}"
 		lib_postfix="so"
 		;;
 	Darwin*)
-		executable_name=`basename "${executable_name}" .app`
-		real_executable_name=`defaults read "${PWD}/${executable_name}.app/Contents/Info" CFBundleExecutable`
-		executable_path="${PWD}/${executable_name}.app/Contents/MacOS/${real_executable_name}"
+		executable_name=$(basename "${executable_name}" .app)
+		real_executable_name=$(defaults read "${VALHEIM_PLUS_PATH}/${executable_name}.app/Contents/Info" CFBundleExecutable)
+		executable_path="${VALHEIM_PLUS_PATH}/${executable_name}.app/Contents/MacOS/${real_executable_name}"
 		lib_postfix="dylib"
 		;;
 	*)
@@ -65,7 +69,7 @@ case $os_type in
 		;;
 esac
 
-executable_type=`LD_PRELOAD="" file -b "${executable_path}"`;
+executable_type=$(LD_PRELOAD="" file -b "${executable_path}");
 
 case $executable_type in
 	*64-bit*)
@@ -88,7 +92,7 @@ export DYLD_LIBRARY_PATH="${doorstop_libs}"
 export DYLD_INSERT_LIBRARIES="${doorstop_libs}/$doorstop_libname"
 
 export templdpath="$LD_LIBRARY_PATH"
-LD_LIBRARY_PATH=`./linux64:$LD_LIBRARY_PATH` && export LD_LIBRARY_PATH || export LD_LIBRARY_PATH=./linux64:"$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="${VALHEIM_PLUS_PATH}/linux64":${LD_LIBRARY_PATH}
 export SteamAppId=892970
 
 for arg in "$@"
@@ -117,6 +121,6 @@ do
 	esac
 done
 
-"${PWD}/${executable_name}" -name "${server_name}" -password "${server_password}" -port "${server_port}" -world "${server_world}" -public "${server_public}"
+"${VALHEIM_PLUS_PATH}/${executable_name}" -name "${server_name}" -password "${server_password}" -port "${server_port}" -world "${server_world}" -public "${server_public}"
 
 export LD_LIBRARY_PATH=$templdpath

--- a/resources/unix/start_server_bepinex.sh
+++ b/resources/unix/start_server_bepinex.sh
@@ -25,8 +25,8 @@ server_public=1
 # The rest is automatically handled by BepInEx for Valheim+
 
 # Set base path of start_server_bepinex.sh location
-export VALHEIM_PLUS_SCRIPT=$(readlink -f "$0")
-export VALHEIM_PLUS_PATH=$(dirname "$VALHEIM_PLUS_SCRIPT")
+export VALHEIM_PLUS_SCRIPT="$(readlink -f "$0")"
+export VALHEIM_PLUS_PATH="$(dirname "$VALHEIM_PLUS_SCRIPT")"
 
 # Whether or not to enable Doorstop. Valid values: TRUE or FALSE
 export DOORSTOP_ENABLE=TRUE
@@ -40,7 +40,7 @@ export DOORSTOP_CORLIB_OVERRIDE_PATH="${VALHEIM_PLUS_PATH}/unstripped_corlib"
 # ----- DO NOT EDIT FROM THIS LINE FORWARD  ------
 # ----- (unless you know what you're doing) ------
 
-if [ ! -x "$1" -a ! -x "$executable_name" ]; then
+if [ ! -x "$1" -a ! -x "${VALHEIM_PLUS_PATH}/$executable_name" ]; then
 	echo "Please open start_server_bepinex.sh in a text editor and provide the correct executable."
 	exit 1
 fi
@@ -57,8 +57,8 @@ case $os_type in
 		lib_postfix="so"
 		;;
 	Darwin*)
-		executable_name=$(basename "${executable_name}" .app)
-		real_executable_name=$(defaults read "${VALHEIM_PLUS_PATH}/${executable_name}.app/Contents/Info" CFBundleExecutable)
+		executable_name="$(basename "${executable_name}" .app)"
+		real_executable_name="$(defaults read "${VALHEIM_PLUS_PATH}/${executable_name}.app/Contents/Info" CFBundleExecutable)"
 		executable_path="${VALHEIM_PLUS_PATH}/${executable_name}.app/Contents/MacOS/${real_executable_name}"
 		lib_postfix="dylib"
 		;;
@@ -86,13 +86,13 @@ case $executable_type in
 esac
 
 doorstop_libname=libdoorstop_${arch}.${lib_postfix}
-export LD_LIBRARY_PATH="${doorstop_libs}":${LD_LIBRARY_PATH}
-export LD_PRELOAD=$doorstop_libname:$LD_PRELOAD
+export LD_LIBRARY_PATH="${doorstop_libs}":"${LD_LIBRARY_PATH}"
+export LD_PRELOAD="$doorstop_libname":"${LD_PRELOAD}"
 export DYLD_LIBRARY_PATH="${doorstop_libs}"
 export DYLD_INSERT_LIBRARIES="${doorstop_libs}/$doorstop_libname"
 
 export templdpath="$LD_LIBRARY_PATH"
-export LD_LIBRARY_PATH="${VALHEIM_PLUS_PATH}/linux64":${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH="${VALHEIM_PLUS_PATH}/linux64":"${LD_LIBRARY_PATH}"
 export SteamAppId=892970
 
 for arg in "$@"


### PR DESCRIPTION
the changes to `start_server_bepinex.sh` regarding `LD_LIBRARY_PATH` were causing V+ not to load, thus resulting in the server reporting an incompatible version error.

This pull request contains the following changes
*Change 1*
Changed
```
LD_LIBRARY_PATH=`./linux64:$LD_LIBRARY_PATH` && export LD_LIBRARY_PATH || export LD_LIBRARY_PATH=./linux64:"$LD_LIBRARY_PATH"
```
to
```
export LD_LIBRARY_PATH="${VALHEIM_PLUS_PATH}/linux64":${LD_LIBRARY_PATH}
```
I couldn't see any reason for the first statement other than trying two different ways to export the same variable, so reverted it back to the pre `0.9.5.5` way.

*Change 2*
The method of using `${PWD}` breaks when calling the script from a directory other than the one `start_server_bepinex.sh` is in. This is a problem when run through third party platforms like LGSM. The new `${VALHEIM_PLUS_PATH}` reference will make sure that the path is absolute relative to the location of `start_server_bepinex.sh` regardless of where it's called from, ensuring compatibility with third party launchers.

*Change 3*
the file contained uses of both backticks and `$()` notation. Standardized all references to `$()` notation to be POSIX compliant.