### PR TITLE
Support savedir argument

### DIFF
--- a/resources/unix/start_server_bepinex.sh
+++ b/resources/unix/start_server_bepinex.sh
@@ -21,6 +21,7 @@ server_password="password"
 server_port=2456
 server_world="world"
 server_public=1
+server_savedir="$HOME/.config/unity3d/IronGate/Valheim"
 
 # The rest is automatically handled by BepInEx for Valheim+
 
@@ -118,9 +119,13 @@ do
 	server_public=$2
 	shift 2
 	;;
+	-savedir)
+	server_savedir=$2
+	shift 2
+	;;
 	esac
 done
 
-"${VALHEIM_PLUS_PATH}/${executable_name}" -name "${server_name}" -password "${server_password}" -port "${server_port}" -world "${server_world}" -public "${server_public}"
+"${VALHEIM_PLUS_PATH}/${executable_name}" -name "${server_name}" -password "${server_password}" -port "${server_port}" -world "${server_world}" -public "${server_public}" -savedir "${server_savedir}"
 
 export LD_LIBRARY_PATH=$templdpath


### PR DESCRIPTION
This arg is configurable with LinuxGSM. See: https://github.com/GameServerManagers/LinuxGSM/blob/532443eafeee33706399a980070be70e2d5693fd/lgsm/config-default/config-lgsm/vhserver/_default.cfg#L21

FWIW I overwrite the save directory in my LGSM setup with `savedir="${serverfiles}/.config/unity3d/IronGate/Valheim"` because this is a subdirectory in an EBS volume and it really makes it much easier to manage the server; replacing hardware, OS, etc. is trivial with all persistent data on an external file system.