### PR TITLE
Add Auto Fuel feature

### DIFF
--- a/ValheimPlus/Configurations/Sections/FireSourceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FireSourceConfiguration.cs
@@ -2,6 +2,10 @@
 {
     public class FireSourceConfiguration : ServerSyncConfig<FireSourceConfiguration>
     {
-        public bool onlyTorches { get; internal set; } = false;
+        public bool torches { get; internal set; } = false;
+        public bool fires { get; internal set; } = false;
+        public bool autoFuel { get; internal set; } = false;
+        public bool ignorePrivateAreaCheck { get; internal set; } = true;
+        public float autoRange { get; internal set; } = 10;
     }
 }

--- a/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
@@ -7,7 +7,9 @@
         public int coalUsedPerProduct { get; set; } = 2;
         public float productionSpeed { get; set; } = 30;
         public bool autoDeposit { get; set; } = false;
-        public float autoDepositRange { get; set; } = 10;
+        public bool autoFuel { get; set; } = false;
+        public bool ignorePrivateAreaCheck { get; internal set; } = true;
+        public float autoRange { get; set; } = 10;
     }
 
 }

--- a/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
@@ -5,7 +5,9 @@
         public float productionSpeed { get; set; } = 10;
         public int maximumWood { get; internal set; } = 25;
         public bool autoDeposit { get; set; } = false;
-        public float autoDepositRange { get; set; } = 10;
+        public bool autoFuel { get; set; } = false;
+        public bool ignorePrivateAreaCheck { get; internal set; } = true;
+        public float autoRange { get; set; } = 10;
     }
 
 }

--- a/ValheimPlus/Configurations/Sections/SmelterConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/SmelterConfiguration.cs
@@ -7,7 +7,9 @@
         public int coalUsedPerProduct { get; set; } = 2;
         public float productionSpeed { get; set; } = 30;
         public bool autoDeposit { get; set; } = false;
-        public float autoDepositRange { get; set; } = 10;
+        public bool autoFuel { get; set; } = false;
+        public bool ignorePrivateAreaCheck { get; internal set; } = true;
+        public float autoRange { get; set; } = 10;
     }
 
 }

--- a/ValheimPlus/GameClasses/Beehive.cs
+++ b/ValheimPlus/GameClasses/Beehive.cs
@@ -93,7 +93,7 @@ namespace ValheimPlus.GameClasses
             // Allows for access for linq
             Beehive beehive = __instance; // allowing access to local function
 
-            if (!Configuration.Current.Beehive.autoDeposit || !Configuration.Current.Beehive.IsEnabled)
+            if (!Configuration.Current.Beehive.autoDeposit || !Configuration.Current.Beehive.IsEnabled || !beehive.m_nview.IsOwner())
                 return true;
 
             // if behive is empty

--- a/ValheimPlus/GameClasses/Smelter.cs
+++ b/ValheimPlus/GameClasses/Smelter.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using ValheimPlus.Configurations;
 
@@ -52,6 +51,8 @@ namespace ValheimPlus.GameClasses
         private static bool Prefix(string ore, int stack, ref Smelter __instance)
         {
             Smelter smelter = __instance; // allowing access to local function
+            if (!smelter.m_nview.IsOwner())
+                return true;
 
             if (__instance.m_name.Equals(SmelterDefinitions.KilnName))
             {
@@ -59,7 +60,7 @@ namespace ValheimPlus.GameClasses
                 {
                     if (Configuration.Current.Kiln.autoDeposit)
                     {
-                        bool result = spawn(Configuration.Current.Kiln.autoDepositRange);
+                        bool result = spawn(Helper.Clamp(Configuration.Current.Kiln.autoRange, 1, 50), Configuration.Current.Kiln.ignorePrivateAreaCheck);
                         return result;
                     }
                 }
@@ -70,7 +71,7 @@ namespace ValheimPlus.GameClasses
                 {
                     if (Configuration.Current.Smelter.autoDeposit)
                     {
-                        bool result = spawn(Configuration.Current.Smelter.autoDepositRange);
+                        bool result = spawn(Helper.Clamp(Configuration.Current.Smelter.autoRange, 1, 50), Configuration.Current.Smelter.ignorePrivateAreaCheck);
                         return result;
                     }
                 }
@@ -80,15 +81,15 @@ namespace ValheimPlus.GameClasses
                 if (Configuration.Current.Furnace.IsEnabled)
                 {
                     if (Configuration.Current.Furnace.autoDeposit)
-                    {   
-                        bool result = spawn(Configuration.Current.Furnace.autoDepositRange);
+                    {
+                        bool result = spawn(Helper.Clamp(Configuration.Current.Furnace.autoRange, 1, 50), Configuration.Current.Furnace.ignorePrivateAreaCheck);
                         return result;
                     }
                 }
             }
-            bool spawn(float autoDepositRange)
+            bool spawn(float autoDepositRange, bool ignorePrivateAreaCheck)
             {
-                List<Container> nearbyChests = InventoryAssistant.GetNearbyChests(smelter.gameObject, autoDepositRange);
+                List<Container> nearbyChests = InventoryAssistant.GetNearbyChests(smelter.gameObject, autoDepositRange, !ignorePrivateAreaCheck);
                 if (nearbyChests.Count == 0)
                     return true;
 
@@ -102,7 +103,7 @@ namespace ValheimPlus.GameClasses
 
                 // Also replication of original code, really have no idead what it is for, didn't bother look
                 ZNetView.m_forceDisableInit = true;
-                GameObject spawnedOre = UnityEngine.Object.Instantiate<GameObject>(itemPrefab);
+                GameObject spawnedOre = Object.Instantiate<GameObject>(itemPrefab);
                 ZNetView.m_forceDisableInit = false;
 
                 // assign stack size, nobody wants a 0/20 stack of metals (its not very usefull)
@@ -139,12 +140,91 @@ namespace ValheimPlus.GameClasses
                 }
                 return result;
             }
-            
+
 
             return true;
         }
     }
 
+    [HarmonyPatch(typeof(Smelter), "FixedUpdate")]
+    public static class Smelter_FixedUpdate_Patch
+    {
+        static void Postfix(ref Smelter __instance)
+        {
+            Smelter smelter = __instance;
+
+            if (smelter == null || !Player.m_localPlayer || !smelter.m_nview.IsOwner())
+                return;
+
+            float autoFuelRange = 0f;
+            bool ignorePrivateAreaCheck = false;
+            if (smelter.m_name.Equals(SmelterDefinitions.KilnName))
+            {
+                if (!Configuration.Current.Kiln.IsEnabled || !Configuration.Current.Kiln.autoFuel)
+                    return;
+                autoFuelRange = Configuration.Current.Kiln.autoRange;
+                ignorePrivateAreaCheck = Configuration.Current.Kiln.ignorePrivateAreaCheck;
+            }
+            else if (smelter.m_name.Equals(SmelterDefinitions.SmelterName))
+            {
+                if (!Configuration.Current.Smelter.IsEnabled || !Configuration.Current.Smelter.autoFuel)
+                    return;
+                autoFuelRange = Configuration.Current.Smelter.autoRange;
+                ignorePrivateAreaCheck = Configuration.Current.Smelter.ignorePrivateAreaCheck;
+            }
+            else if (smelter.m_name.Equals(SmelterDefinitions.FurnaceName))
+            {
+                if (!Configuration.Current.Furnace.IsEnabled || !Configuration.Current.Furnace.autoFuel)
+                    return;
+                autoFuelRange = Configuration.Current.Furnace.autoRange;
+                ignorePrivateAreaCheck = Configuration.Current.Furnace.ignorePrivateAreaCheck;
+            }
+            autoFuelRange = Helper.Clamp(autoFuelRange, 1, 50);
+
+            int toMaxOre = smelter.m_maxOre - smelter.GetQueueSize();
+            int toMaxFuel = smelter.m_maxFuel - (int)System.Math.Ceiling(smelter.GetFuel());
+
+            if (smelter.m_fuelItem && toMaxFuel > 0)
+            {
+                ItemDrop.ItemData fuelItemData = smelter.m_fuelItem.m_itemData;
+
+                // Check for fuel in nearby containers
+                int addedFuel = InventoryAssistant.RemoveItemInAmountFromAllNearbyChests(smelter.gameObject, autoFuelRange, fuelItemData, toMaxFuel, !ignorePrivateAreaCheck);
+                for (int i = 0; i < addedFuel; i++)
+                {
+                    smelter.m_nview.InvokeRPC("AddFuel", new object[] { });
+                }
+                if (addedFuel > 0)
+                    ZLog.Log("Added " + addedFuel + " fuel(" + fuelItemData.m_shared.m_name + ") in " + smelter.m_name);
+            }
+            if (toMaxOre > 0)
+            {
+                List<Container> nearbyChests = InventoryAssistant.GetNearbyChests(smelter.gameObject, autoFuelRange);
+                foreach (Container c in nearbyChests)
+                {
+                    foreach (Smelter.ItemConversion itemConversion in smelter.m_conversion)
+                    {
+                        ItemDrop.ItemData oreItem = itemConversion.m_from.m_itemData;
+                        int addedOres = InventoryAssistant.RemoveItemFromChest(c, oreItem, toMaxOre);
+                        if (addedOres > 0)
+                        {
+                            GameObject orePrefab = ObjectDB.instance.GetItemPrefab(itemConversion.m_from.gameObject.name);
+
+                            for (int i = 0; i < addedOres; i++)
+                            {
+                                smelter.m_nview.InvokeRPC("AddOre", new object[] { orePrefab.name });
+                            }
+                            toMaxOre -= addedOres;
+                            if (addedOres > 0)
+                                ZLog.Log("Added " + addedOres + " ores(" + oreItem.m_shared.m_name + ") in " + smelter.m_name);
+                            if (toMaxOre == 0)
+                                return;
+                        }
+                    }
+                }
+            }
+        }
+    }
     public static class SmelterDefinitions
     {
         public static readonly string KilnName = "$piece_charcoalkiln";

--- a/ValheimPlus/Utility/Helper.cs
+++ b/ValheimPlus/Utility/Helper.cs
@@ -109,5 +109,11 @@ namespace ValheimPlus
         {
             return Math.Min(max, Math.Max(min, value));
         }
+
+        // Clamp value between min and max
+        public static float Clamp(float value, float min, float max)
+        {
+            return Math.Min(max, Math.Max(min, value));
+        }
     }
 }

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -14,7 +14,7 @@ namespace ValheimPlus
         /// <summary>
         /// Get all valid nearby chests
         /// </summary>
-        public static List<Container> GetNearbyChests(GameObject target, float range)
+        public static List<Container> GetNearbyChests(GameObject target, float range, bool checkWard = true)
         {
             Collider[] hitColliders = Physics.OverlapSphere(target.transform.localPosition, range, LayerMask.GetMask(new string[] { "piece" }));
 
@@ -27,7 +27,9 @@ namespace ValheimPlus
                 try
                 {
                     Container foundContainer = hitCollider.GetComponentInParent<Container>();
-                    if (foundContainer.m_name.Contains("piece_chest") && foundContainer.GetInventory() != null)
+                    bool hasAccess = foundContainer.CheckAccess(Player.m_localPlayer.GetPlayerID());
+                    if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(target.transform.position, flash: false);
+                    if (foundContainer.m_name.Contains("piece_chest") && hasAccess && foundContainer.GetInventory() != null)
                     {
                         validContainers.Add(foundContainer);
                     }
@@ -41,9 +43,9 @@ namespace ValheimPlus
         /// <summary>
         /// Get a chests that contain the specified itemInfo.m_shared.m_name (item name)
         /// </summary>
-        public static List<Container> GetNearbyChestsWithItem(GameObject target, float range, ItemDrop.ItemData itemInfo)
+        public static List<Container> GetNearbyChestsWithItem(GameObject target, float range, ItemDrop.ItemData itemInfo, bool checkWard = true)
         {
-            List<Container> nearbyChests = GetNearbyChests(target, range);
+            List<Container> nearbyChests = GetNearbyChests(target, range, checkWard);
 
             List<Container> validChests = new List<Container>();
             foreach (Container chest in nearbyChests)
@@ -76,10 +78,10 @@ namespace ValheimPlus
         /// <summary>
         /// function to get all items in nearby chests by range
         /// </summary>
-        public static List<ItemDrop.ItemData> GetNearbyChestItems(GameObject target, float range = 10)
+        public static List<ItemDrop.ItemData> GetNearbyChestItems(GameObject target, float range = 10, bool checkWard = true)
         {
             List<ItemDrop.ItemData> itemList = new List<ItemDrop.ItemData>();
-            List<Container> nearbyChests = GetNearbyChests(target, range);
+            List<Container> nearbyChests = GetNearbyChests(target, range, checkWard);
 
             foreach (Container chest in nearbyChests)
             {
@@ -124,9 +126,9 @@ namespace ValheimPlus
         }
 
         // function to remove items in the amount from all nearby chests
-        public static bool RemoveItemInAmountFromAllNearbyChests(GameObject target, float range, ItemDrop.ItemData needle, int amount)
+        public static int RemoveItemInAmountFromAllNearbyChests(GameObject target, float range, ItemDrop.ItemData needle, int amount, bool checkWard = true)
         {
-            List<Container> nearbyChests = GetNearbyChests(target, range);
+            List<Container> nearbyChests = GetNearbyChests(target, range, checkWard);
 
             // check if there are enough items nearby
             List<ItemDrop.ItemData> allItems = GetNearbyChestItemsByContainerList(nearbyChests);
@@ -136,7 +138,7 @@ namespace ValheimPlus
 
             // check if there are enough items
             if (availableAmount < amount || amount == 0)
-                return false;
+                return 0;
 
             // iterate all chests and remove as many items as possible for the respective chest
             int itemsRemovedTotal = 0;
@@ -150,7 +152,7 @@ namespace ValheimPlus
                 }
             }
 
-            return true;
+            return itemsRemovedTotal;
         }
 
         // function to add a item by name/ItemDrop.ItemData to a specified chest

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -176,14 +176,32 @@ showDuration=false
 
 [FireSource]
 
-; If set to true, all fire sources will stay at max fuel level once filled.
+; Change false to true to enable this section
 ; default: false
 enabled=false
 
-; If set to true, only torch-type fire sources will stay at max fuel level once filled. NOTE: Requires enabled=true above.
+; If set to true, torch-type fire sources will stay at max fuel level once filled.
 ; Applies to: wood torches, iron torches, green torches, sconces and brazier
 ; default: false
-onlyTorches=false
+torches=false
+
+; If set to true, non torch-type fire sources will stay at max fuel level once filled.
+; default: false
+fires=true
+
+; Look for fuel inside nearby chests.
+; default: false
+autoFuel=false
+
+; Ignore private area check.
+; default: true
+ignorePrivateAreaCheck=true
+
+; The range of the chest detection for the auto fuel features.
+; default: 10
+; min: 1
+; max: 50
+autoRange=10
 
 [Food]
 
@@ -217,8 +235,15 @@ productionSpeed=30
 ; Instead of dropping the items, they will be placed inside nearby chests instead.
 autoDeposit=false
 
-; The range of the chest detection for the auto deposit feature. (Maximum is 50)
-autoDepositRange=10
+; Look for fuel inside nearby chests.
+autoFuel=false
+
+; Ignore private area check.
+; default: true
+ignorePrivateAreaCheck=true
+
+; The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)
+autoRange=10
 
 [Furnace]
 
@@ -240,8 +265,15 @@ productionSpeed=30
 ; Instead of dropping the items, they will be placed inside nearby chests instead.
 autoDeposit=false
 
-; The range of the chest detection for the auto deposit feature. (Maximum is 50)
-autoDepositRange=10
+; Look for fuel inside nearby chests.
+autoFuel=false
+
+; Ignore private area check.
+; default: true
+ignorePrivateAreaCheck=true
+
+; The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)
+autoRange=10
 
 [Game]
 
@@ -380,8 +412,15 @@ productionSpeed=30
 ; Instead of dropping the items, they will be placed inside nearby chests instead.
 autoDeposit=false
 
-; The range of the chest detection for the auto deposit feature. (Maximum is 50)
-autoDepositRange=10
+; Look for fuel inside nearby chests.
+autoFuel=false
+
+; Ignore private area check.
+; default: true
+ignorePrivateArea=true
+
+; The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)
+autoRange=10
 
 [Map]
 

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -378,14 +378,34 @@
 		"description_website": "Change the in-game beheavior of torches and fireplaces.",
 		"entries": {
 			"enabled": {
-				"description": "If set to true, all fire sources will stay at max fuel level once filled.",
+				"description": "Change false to true to enable this section",
 				"defaultValue": "false",
 				"defaultType": "bool"
 			},
-			"onlyTorches": {
-				"description": "If set to true, only torch-type fire sources will stay at max fuel level once filled. NOTE: Requires enabled=true above.",
+			"torches": {
+				"description": "If set to true, torch-type fire sources will stay at max fuel level once filled",
 				"defaultValue": "false",
 				"defaultType": "bool"
+			},
+			"fires": {
+				"description": "If set to true, non torch-type fire sources will stay at max fuel level once filled",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
+			"autoFuel": {
+				"description": "Look for fuel inside nearby chests",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
+			"ignorePrivateAreaCheck": {
+				"description": "Change true to false to enable private area check when looking for chests.",
+				"defaultValue": "true",
+				"defaultType": "bool"	
+			},
+			"autoRange": {
+				"description": "The range of the chest detection for the auto fuel feature.",
+				"defaultValue": 10,
+				"defaultType": "float",
 			}
 		}
 	},
@@ -447,8 +467,18 @@
 				"defaultValue": "false",
 				"defaultType": "bool"
 			},
-			"autoDepositRange": {
-				"description": "The range of the chest detection for the auto deposit feature. (Maximum is 50)",
+			"autoFuel": {
+				"description": "Look for fuel inside nearby chests",
+				"defaultValue": "false",
+				"defaultType": "bool"	
+			},
+			"ignorePrivateAreaCheck": {
+				"description": "Change true to false to enable private area check when looking for chests.",
+				"defaultValue": "true",
+				"defaultType": "bool"	
+			},
+			"autoRange": {
+				"description": "The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)",
 				"defaultValue": "10",
 				"defaultType": "float"
 			}
@@ -489,8 +519,18 @@
 				"defaultValue": "false",
 				"defaultType": "bool"
 			},
-			"autoDepositRange": {
-				"description": "The range of the chest detection for the auto deposit feature. (Maximum is 50)",
+			"autoFuel": {
+				"description": "Look for fuel inside nearby chests",
+				"defaultValue": "false",
+				"defaultType": "bool"	
+			},
+			"ignorePrivateAreaCheck": {
+				"description": "Change true to false to enable private area check when looking for chests.",
+				"defaultValue": "true",
+				"defaultType": "bool"	
+			},
+			"autoRange": {
+				"description": "The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)",
 				"defaultValue": "10",
 				"defaultType": "float"
 			}
@@ -837,8 +877,18 @@
 				"defaultValue": "false",
 				"defaultType": "bool"
 			},
-			"autoDepositRange": {
-				"description": "The range of the chest detection for the auto deposit feature. (Maximum is 50)",
+			"autoFuel": {
+				"description": "Look for fuel inside nearby chests",
+				"defaultValue": "false",
+				"defaultType": "bool"	
+			},
+			"ignorePrivateAreaCheck": {
+				"description": "Change true to false to enable private area check when looking for chests.",
+				"defaultValue": "true",
+				"defaultType": "bool"	
+			},
+			"autoRange": {
+				"description": "The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)",
 				"defaultValue": "10",
 				"defaultType": "float"
 			}


### PR DESCRIPTION
Allow the Kiln, Smelter, Furnace, Torches and fire places to pull fuel (wood, coal, ores,...) from nearby chests.

It uses the same range as the autoDrop feature.

Due to the way the game is made, we can't add a specific amount for fuel.
It means each item used as fuel we send something over the network, which isn't the best due to the limited dataRate.

To avoid any unecessary trouble like going over the fuel limit, only the peer having ownership of the current zone will have this feature enabled.

_Note: `autoDepositRange` has been renamed to `autoRange` for clarity_ 