### PR TITLE
Auto Equip Shield Feature (Ref: #113)

### DIFF
--- a/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
@@ -13,5 +13,6 @@
         public bool autoRepair { get; internal set; } = false;
         public float guardianBuffDuration { get; internal set; } = 300;
         public float guardianBuffCooldown { get; internal set; } = 1200;
+        public bool autoEquipShield { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/Humanoid.cs
+++ b/ValheimPlus/GameClasses/Humanoid.cs
@@ -1,10 +1,6 @@
 ﻿using HarmonyLib;
 using ValheimPlus.Configurations;
-using UnityEngine;
 using System.Collections.Generic;
-using BepInEx.Logging;
-using HarmonyLib.Tools;
-using System;
 
 namespace ValheimPlus.GameClasses
 {

--- a/ValheimPlus/GameClasses/Humanoid.cs
+++ b/ValheimPlus/GameClasses/Humanoid.cs
@@ -1,6 +1,10 @@
 ﻿using HarmonyLib;
 using ValheimPlus.Configurations;
 using UnityEngine;
+using System.Collections.Generic;
+using BepInEx.Logging;
+using HarmonyLib.Tools;
+using System;
 
 namespace ValheimPlus.GameClasses
 {
@@ -22,6 +26,49 @@ namespace ValheimPlus.GameClasses
             }
 
             return __weapon;
+        }
+    }
+
+    /// <summary>
+    /// When equipping a one-handed weapon, also equip best shield from inventory.
+    /// </summary>
+    [HarmonyPatch(typeof(Humanoid), "EquipItem")]
+    public static class Humanoid_EquipItem_Patch
+    {
+        private static bool Postfix(bool __result, Humanoid __instance)
+        {
+            if (__result && __instance.IsPlayer() && __instance.m_rightItem?.m_shared.m_itemType == ItemDrop.ItemData.ItemType.OneHandedWeapon)
+            {
+                List<ItemDrop.ItemData> inventoryItems = __instance.m_inventory.GetAllItems();
+
+                ItemDrop.ItemData bestShield = null;
+                foreach (ItemDrop.ItemData inventoryItem in inventoryItems)
+                {
+                    if (inventoryItem.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Shield)
+                    {
+                        if (bestShield == null)
+                        {
+                            bestShield = inventoryItem;
+
+                            continue;
+                        }
+
+                        if (bestShield.m_shared.m_blockPower < inventoryItem.m_shared.m_blockPower)
+                        {
+                            bestShield = inventoryItem;
+
+                            continue;
+                        }
+                    }
+                }
+
+                if (bestShield != null)
+                {
+                    __instance.EquipItem(bestShield, false);
+                }
+            }
+
+            return __result;
         }
     }
 }

--- a/ValheimPlus/GameClasses/Humanoid.cs
+++ b/ValheimPlus/GameClasses/Humanoid.cs
@@ -33,7 +33,11 @@ namespace ValheimPlus.GameClasses
     {
         private static bool Postfix(bool __result, Humanoid __instance)
         {
-            if (__result && __instance.IsPlayer() && __instance.m_rightItem?.m_shared.m_itemType == ItemDrop.ItemData.ItemType.OneHandedWeapon)
+            if (Configuration.Current.Player.IsEnabled &&
+                Configuration.Current.Player.autoEquipShield &&
+                __result && 
+                __instance.IsPlayer() && 
+                __instance.m_rightItem?.m_shared.m_itemType == ItemDrop.ItemData.ItemType.OneHandedWeapon)
             {
                 List<ItemDrop.ItemData> inventoryItems = __instance.m_inventory.GetAllItems();
 

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -415,6 +415,9 @@ guardianBuffDuration=300
 ; Boss buff cooldown (seconds)
 guardianBuffCooldown=1200
 
+; If set to true, when equipping a one-handed weapon, the best shield from your inventory is automatically equipped. (Best is determined by highest block power)
+autoEquipShield=false
+
 
 [Server]
 


### PR DESCRIPTION
**Feature Request:** https://github.com/valheimPlus/ValheimPlus/issues/113
**Trello Card:** https://trello.com/c/ciLlJps6/21-auto-equip-shield

Adds configuration "autoEquipShield" under [Player]
If enabled and player is equipping a one-handed weapon, checks players inventory for a shield with the highest "block power" and also equips it. 

Confirmed working on clean install with V+ v0.9.5.5

Let me know if there's any issues, or optimizations or if this needs to be a hotkey also/instead. First modification, and first time actually coding anything for Valheim so keep that in mind if I did anything stupid. 