### PR TITLE
Added configuration for advanced building/editing mode scroll speed hotkeys (Ref: #146)

### DIFF
--- a/ValheimPlus/AdvancedBuildingMode.cs
+++ b/ValheimPlus/AdvancedBuildingMode.cs
@@ -385,7 +385,7 @@ namespace ValheimPlus
             if (shiftFlag)
                 incValue = 10;
 
-            if (Input.GetKeyDown(KeyCode.KeypadPlus)) 
+            if (Input.GetKeyDown(Configuration.Current.AdvancedBuildingMode.increaseScrollSpeed)) 
             {
                 if ((gScrollDistance - incValue) < 360)
                     gScrollDistance += incValue;
@@ -397,7 +397,7 @@ namespace ValheimPlus
                 Debug.Log("Modification Speed: " + gDistance);
             }
 
-            if (Input.GetKeyDown(KeyCode.KeypadMinus))
+            if (Input.GetKeyDown(Configuration.Current.AdvancedBuildingMode.decreaseScrollSpeed))
             {
                 if((gScrollDistance-incValue) > 0)
                     gScrollDistance = gScrollDistance - incValue;

--- a/ValheimPlus/AdvancedEditingMode.cs
+++ b/ValheimPlus/AdvancedEditingMode.cs
@@ -459,7 +459,7 @@ namespace ValheimPlus
             if (shiftFlag)
                 incValue = 10;
 
-            if (Input.GetKeyDown(KeyCode.KeypadPlus))
+            if (Input.GetKeyDown(Configuration.Current.AdvancedEditingMode.increaseScrollSpeed))
             {
 
                 if ((gScrollDistance - incValue) < 360)
@@ -470,7 +470,7 @@ namespace ValheimPlus
                 notifyUser("Modification Speed: " + gDistance);
                 Debug.Log("Modification Speed: " + gDistance);
             }
-            if (Input.GetKeyDown(KeyCode.KeypadMinus))
+            if (Input.GetKeyDown(Configuration.Current.AdvancedEditingMode.decreaseScrollSpeed))
             {
 
                 if ((gScrollDistance - incValue) > 0)

--- a/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
@@ -9,5 +9,8 @@ namespace ValheimPlus.Configurations.Sections
 
         public KeyCode copyObjectRotation { get; set; } = KeyCode.Keypad7;
         public KeyCode pasteObjectRotation { get; set; } = KeyCode.Keypad8;
+
+        public KeyCode increaseScrollSpeed { get; set; } = KeyCode.KeypadPlus;
+        public KeyCode decreaseScrollSpeed { get; set; } = KeyCode.KeypadMinus;
     }
 }

--- a/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
@@ -14,5 +14,8 @@ namespace ValheimPlus.Configurations.Sections
         public KeyCode confirmPlacementOfAdvancedEditingMode { get; internal set; } = KeyCode.KeypadEnter;
         public KeyCode copyObjectRotation { get; set; } = KeyCode.Keypad7;
         public KeyCode pasteObjectRotation { get; set; } = KeyCode.Keypad8;
+
+        public KeyCode increaseScrollSpeed { get; set; } = KeyCode.KeypadPlus;
+        public KeyCode decreaseScrollSpeed { get; set; } = KeyCode.KeypadMinus;
     }
 }

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -16,6 +16,14 @@ copyObjectRotation=Keypad7
 ; Apply the copied object rotation to the currently selected object in ABM
 pasteObjectRotation=Keypad8
 
+; Increases the amount an object rotates and moves.
+; Holding Shift will increase in increments of 10 instead of 1.
+increaseScrollSpeed=KeypadPlus
+
+; Decreases the amount an object rotates and moves.
+; Holding Shift will decrease in increments of 10 instead of 1.
+decreaseScrollSpeed=KeypadMinus
+
 [AdvancedEditingMode]
 
 ; Change false to true to enable this section, if you set this to false the mode will not be accesible
@@ -40,6 +48,14 @@ copyObjectRotation=Keypad7
 
 ; Apply the copied object rotation to the currently selected object in AEM
 pasteObjectRotation=Keypad8
+
+; Increases the amount an object rotates and moves.
+; Holding Shift will increase in increments of 10 instead of 1.
+increaseScrollSpeed=KeypadPlus
+
+; Decreases the amount an object rotates and moves.
+; Holding Shift will decrease in increments of 10 instead of 1.
+decreaseScrollSpeed=KeypadMinus
 
 [Beehive]
 


### PR DESCRIPTION
**Feature Request:** #146
**Trello Card:** https://trello.com/c/xFfNAfcn/10-allow-configuring-the-key-that-changes-the-advanced-building-mode-speeds

Adds configuration to both [AdvancedBuildingMode] and [AdvancedEditingMode] settings "increaseScrollSpeed" and "decreaseScrollSpeed" corresponding to previous hard-coded defaults of KeypadPlus and KeypadMinus.