### PR TITLE
Allows players to craft from nearby containers

### DIFF
--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -41,6 +41,7 @@ namespace ValheimPlus.Configurations
         public ShieldConfiguration Shields { get; set; }
         public FirstPersonConfiguration FirstPerson { get; internal set; }
         public GridAlignmentConfiguration GridAlignment { get; set; }
+        public CraftFromChestConfiguration CraftFromChest { get; set; }
         public ValheimPlusConfiguration ValheimPlus { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/Sections/CraftFromChestConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/CraftFromChestConfiguration.cs
@@ -1,0 +1,10 @@
+﻿namespace ValheimPlus.Configurations.Sections
+{
+    public class CraftFromChestConfiguration : ServerSyncConfig<CraftFromChestConfiguration>
+    {
+        public float range { get; internal set; } = 20;
+        public bool checkFromWorkbench { get; internal set; } = true;
+        public bool ignorePrivateAreaCheck { get; internal set; } = true;
+        public int lookupInterval { get; internal set; } = 3;
+    }
+}

--- a/ValheimPlus/GameClasses/Container.cs
+++ b/ValheimPlus/GameClasses/Container.cs
@@ -43,6 +43,8 @@ namespace ValheimPlus
         {
             if (!Configuration.Current.Inventory.IsEnabled) return;
 
+            if (__instance == null || ___m_inventory == null) return;
+
             string containerName = __instance.transform.parent.name;
             string inventoryName = ___m_inventory.m_name;
             ref int inventoryColumns = ref ___m_inventory.m_width;

--- a/ValheimPlus/GameClasses/CookingStation.cs
+++ b/ValheimPlus/GameClasses/CookingStation.cs
@@ -1,0 +1,89 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+using ValheimPlus.Configurations;
+
+namespace ValheimPlus.GameClasses
+{
+    [HarmonyPatch(typeof(CookingStation), nameof(CookingStation.FindCookableItem))]
+    public static class CookingStation_FindCookableItem_Transpiler
+    {
+        private static Stopwatch delta = new Stopwatch();
+        private static List<Container> nearbyChests = null;
+
+        private static MethodInfo method_PullCookableItemFromNearbyChests = AccessTools.Method(typeof(CookingStation_FindCookableItem_Transpiler), nameof(CookingStation_FindCookableItem_Transpiler.PullCookableItemFromNearbyChests));
+
+        /// <summary>
+        /// Patches out the code that looks for cookable items in player inventory.
+        /// When not cookables items have been found in the player inventory, check inside nearby chests.
+        /// If found, remove the item from the chests it was in, instantiate a game object and returns it so it can be placed on the CookingStation.
+        /// </summary>
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            if (!Configuration.Current.CraftFromChest.IsEnabled) return instructions;
+
+            List<CodeInstruction> il = instructions.ToList();
+            int endIdx = -1;
+            for (int i = 0; i < il.Count; i++)
+            {
+                if (il[i].opcode == OpCodes.Ldnull)
+                {
+                    il[i] = new CodeInstruction(OpCodes.Ldarg_0)
+                    {
+                        labels = il[i].labels
+                    };
+                    il.Insert(++i, new CodeInstruction(OpCodes.Call, method_PullCookableItemFromNearbyChests));
+                    il.Insert(++i, new CodeInstruction(OpCodes.Stloc_3));
+                    il.Insert(++i, new CodeInstruction(OpCodes.Ldloc_3));
+                    endIdx = i;
+                    break;
+                }
+            }
+            if (endIdx == -1)
+            {
+                ZLog.LogError("Failed to apply CookingStation_FindCookableItem_Transpiler");
+                return instructions;
+            }
+
+            return il.AsEnumerable();
+        }
+
+        private static ItemDrop.ItemData PullCookableItemFromNearbyChests(CookingStation station)
+        {
+            int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
+            if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
+            {
+                nearbyChests = InventoryAssistant.GetNearbyChests(station.gameObject, Helper.Clamp(Configuration.Current.CraftFromChest.range, 1, 50), !Configuration.Current.CraftFromChest.ignorePrivateAreaCheck);
+                delta.Restart();
+            }
+
+            foreach (CookingStation.ItemConversion itemConversion in station.m_conversion)
+            {
+                ItemDrop.ItemData itemData = itemConversion.m_from.m_itemData;
+
+                foreach (Container c in nearbyChests)
+                {
+                    if (c.GetInventory().HaveItem(itemData.m_shared.m_name))
+                    {
+                        // Remove one item from chest
+                        InventoryAssistant.RemoveItemFromChest(c, itemData);
+                        // Instantiate cookabled GameObject
+                        GameObject itemPrefab = ObjectDB.instance.GetItemPrefab(itemConversion.m_from.gameObject.name);
+
+                        ZNetView.m_forceDisableInit = true;
+                        GameObject cookabledItem = UnityEngine.Object.Instantiate<GameObject>(itemPrefab);
+                        ZNetView.m_forceDisableInit = false;
+
+                        return cookabledItem.GetComponent<ItemDrop>().m_itemData;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -2,6 +2,7 @@ using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using UnityEngine;
@@ -10,129 +11,130 @@ using ValheimPlus.Configurations;
 
 namespace ValheimPlus.GameClasses
 {
-	
-	[HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.Show))]
-	public class InventoryGui_Show_Patch 
-	{
-		private const float oneRowSize = 70.5f;
-		private const float containerOriginalY = -90.0f;
-		private const float containerHeight = -340.0f;
-		private static float lastValue = 0;
 
-		public static void Postfix(ref InventoryGui __instance) 
-		{
-			if (Configuration.Current.Inventory.IsEnabled) {
-				RectTransform container = __instance.m_container;
-				RectTransform player = __instance.m_player;
-				GameObject playerGrid = InventoryGui.instance.m_playerGrid.gameObject;
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.Show))]
+    public class InventoryGui_Show_Patch
+    {
+        private const float oneRowSize = 70.5f;
+        private const float containerOriginalY = -90.0f;
+        private const float containerHeight = -340.0f;
+        private static float lastValue = 0;
 
-				// Player inventory background size, only enlarge it up to 6x8 rows, after that use the scroll bar
-				int playerInventoryBackgroundSize = Math.Min(6, Math.Max(4, Configuration.Current.Inventory.playerInventoryRows));
-				float containerNewY = containerOriginalY - oneRowSize * playerInventoryBackgroundSize;
-				// Resize player inventory
-				player.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, playerInventoryBackgroundSize * oneRowSize);
-				// Move chest inventory based on new player invetory size
-				container.offsetMax = new Vector2(610, containerNewY);
-				container.offsetMin = new Vector2(40, containerNewY + containerHeight);
+        public static void Postfix(ref InventoryGui __instance)
+        {
+            if (Configuration.Current.Inventory.IsEnabled)
+            {
+                RectTransform container = __instance.m_container;
+                RectTransform player = __instance.m_player;
+                GameObject playerGrid = InventoryGui.instance.m_playerGrid.gameObject;
 
-				// Add player inventory scroll bar if it does not exist
-				if (!playerGrid.GetComponent < InventoryGrid > ().m_scrollbar) 
-				{
-					GameObject playerGridScroll = GameObject.Instantiate(InventoryGui.instance.m_containerGrid.m_scrollbar.gameObject, playerGrid.transform.parent);
-					playerGridScroll.name = "PlayerScroll";
-					playerGrid.GetComponent < RectMask2D > ().enabled = true;
-					ScrollRect playerScrollRect = playerGrid.AddComponent < ScrollRect > ();
-					playerGrid.GetComponent < RectTransform > ().offsetMax = new Vector2(800f, playerGrid.GetComponent < RectTransform > ().offsetMax.y);
-					playerGrid.GetComponent < RectTransform > ().anchoredPosition = new Vector2(0f, 1f);
-					playerScrollRect.content = playerGrid.GetComponent < InventoryGrid > ().m_gridRoot;
-					playerScrollRect.viewport = __instance.m_player.GetComponentInChildren < RectTransform > ();
-					playerScrollRect.verticalScrollbar = playerGridScroll.GetComponent < Scrollbar > ();
-					playerGrid.GetComponent < InventoryGrid > ().m_scrollbar = playerGridScroll.GetComponent < Scrollbar > ();
+                // Player inventory background size, only enlarge it up to 6x8 rows, after that use the scroll bar
+                int playerInventoryBackgroundSize = Math.Min(6, Math.Max(4, Configuration.Current.Inventory.playerInventoryRows));
+                float containerNewY = containerOriginalY - oneRowSize * playerInventoryBackgroundSize;
+                // Resize player inventory
+                player.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, playerInventoryBackgroundSize * oneRowSize);
+                // Move chest inventory based on new player invetory size
+                container.offsetMax = new Vector2(610, containerNewY);
+                container.offsetMin = new Vector2(40, containerNewY + containerHeight);
 
-					playerScrollRect.horizontal = false;
-					playerScrollRect.movementType = ScrollRect.MovementType.Clamped;
-					playerScrollRect.scrollSensitivity = oneRowSize;
-					playerScrollRect.inertia = false;
-					playerScrollRect.verticalScrollbarVisibility = ScrollRect.ScrollbarVisibility.AutoHide;
-					Scrollbar playerScrollbar = playerGridScroll.GetComponent < Scrollbar > ();
-					lastValue = playerScrollbar.value;
-				}
-			}
-		}
-	}
+                // Add player inventory scroll bar if it does not exist
+                if (!playerGrid.GetComponent<InventoryGrid>().m_scrollbar)
+                {
+                    GameObject playerGridScroll = GameObject.Instantiate(InventoryGui.instance.m_containerGrid.m_scrollbar.gameObject, playerGrid.transform.parent);
+                    playerGridScroll.name = "PlayerScroll";
+                    playerGrid.GetComponent<RectMask2D>().enabled = true;
+                    ScrollRect playerScrollRect = playerGrid.AddComponent<ScrollRect>();
+                    playerGrid.GetComponent<RectTransform>().offsetMax = new Vector2(800f, playerGrid.GetComponent<RectTransform>().offsetMax.y);
+                    playerGrid.GetComponent<RectTransform>().anchoredPosition = new Vector2(0f, 1f);
+                    playerScrollRect.content = playerGrid.GetComponent<InventoryGrid>().m_gridRoot;
+                    playerScrollRect.viewport = __instance.m_player.GetComponentInChildren<RectTransform>();
+                    playerScrollRect.verticalScrollbar = playerGridScroll.GetComponent<Scrollbar>();
+                    playerGrid.GetComponent<InventoryGrid>().m_scrollbar = playerGridScroll.GetComponent<Scrollbar>();
 
-	[HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.RepairOneItem))]
-	public static class InventoryGui_RepairOneItem_Transpiler
-	{
-		private static MethodInfo method_EffectList_Create = AccessTools.Method(typeof(EffectList), nameof(EffectList.Create));
-		private static MethodInfo method_CreateNoop = AccessTools.Method(typeof(InventoryGui_RepairOneItem_Transpiler), nameof(InventoryGui_RepairOneItem_Transpiler.CreateNoop));
+                    playerScrollRect.horizontal = false;
+                    playerScrollRect.movementType = ScrollRect.MovementType.Clamped;
+                    playerScrollRect.scrollSensitivity = oneRowSize;
+                    playerScrollRect.inertia = false;
+                    playerScrollRect.verticalScrollbarVisibility = ScrollRect.ScrollbarVisibility.AutoHide;
+                    Scrollbar playerScrollbar = playerGridScroll.GetComponent<Scrollbar>();
+                    lastValue = playerScrollbar.value;
+                }
+            }
+        }
+    }
 
-		/// <summary>
-		/// Patches out the code that spawns an effect for each item repaired - when we repair multiple items, we only want
-		/// one effect, otherwise it looks and sounds bad. The patch for InventoryGui.UpdateRepair will spawn the effect instead.
-		/// </summary>
-		[HarmonyTranspiler]
-		public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> instructions)
-		{
-			if (!Configuration.Current.Player.IsEnabled) return instructions;
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.RepairOneItem))]
+    public static class InventoryGui_RepairOneItem_Transpiler
+    {
+        private static MethodInfo method_EffectList_Create = AccessTools.Method(typeof(EffectList), nameof(EffectList.Create));
+        private static MethodInfo method_CreateNoop = AccessTools.Method(typeof(InventoryGui_RepairOneItem_Transpiler), nameof(InventoryGui_RepairOneItem_Transpiler.CreateNoop));
 
-			List<CodeInstruction> il = instructions.ToList();
+        /// <summary>
+        /// Patches out the code that spawns an effect for each item repaired - when we repair multiple items, we only want
+        /// one effect, otherwise it looks and sounds bad. The patch for InventoryGui.UpdateRepair will spawn the effect instead.
+        /// </summary>
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> Transpile(IEnumerable<CodeInstruction> instructions)
+        {
+            if (!Configuration.Current.Player.IsEnabled) return instructions;
 
-			if (Configuration.Current.Player.autoRepair)
-			{
-				// We look for a call to EffectList::Create and replace it with our own noop stub.
-				for (int i = 0; i < il.Count; ++i)
-				{
-					if (il[i].Calls(method_EffectList_Create))
-					{
-						il[i].opcode = OpCodes.Call; // original is callvirt, so we need to tweak it
-						il[i].operand = method_CreateNoop;
-					}
-				}
-			}
+            List<CodeInstruction> il = instructions.ToList();
 
-			return il.AsEnumerable();
-		}
+            if (Configuration.Current.Player.autoRepair)
+            {
+                // We look for a call to EffectList::Create and replace it with our own noop stub.
+                for (int i = 0; i < il.Count; ++i)
+                {
+                    if (il[i].Calls(method_EffectList_Create))
+                    {
+                        il[i].opcode = OpCodes.Call; // original is callvirt, so we need to tweak it
+                        il[i].operand = method_CreateNoop;
+                    }
+                }
+            }
 
-		private static GameObject[] CreateNoop(Vector3 _0, Quaternion _1, Transform _2, float _3)
-		{
-			return null;
-		}
-	}
+            return il.AsEnumerable();
+        }
 
-	[HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.UpdateRepair))]
-	public static class InventoryGui_UpdateRepair_Patch
-	{
-		/// <summary>
-		/// When we're in a state where the InventoryGui is open and we have items available to repair,
-		/// and we have an active crafting station, this patch is responsible for repairing all items
-		/// that can be repaired and then spawning one instance of the repair effect if at least one item
-		/// has been repaired.
-		/// </summary>
-		[HarmonyPrefix]
-		public static void Prefix(InventoryGui __instance)
-		{
-			if (!Configuration.Current.Player.IsEnabled || !Configuration.Current.Player.autoRepair) return;
+        private static GameObject[] CreateNoop(Vector3 _0, Quaternion _1, Transform _2, float _3)
+        {
+            return null;
+        }
+    }
 
-			CraftingStation curr_crafting_station = Player.m_localPlayer.GetCurrentCraftingStation();
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.UpdateRepair))]
+    public static class InventoryGui_UpdateRepair_Patch
+    {
+        /// <summary>
+        /// When we're in a state where the InventoryGui is open and we have items available to repair,
+        /// and we have an active crafting station, this patch is responsible for repairing all items
+        /// that can be repaired and then spawning one instance of the repair effect if at least one item
+        /// has been repaired.
+        /// </summary>
+        [HarmonyPrefix]
+        public static void Prefix(InventoryGui __instance)
+        {
+            if (!Configuration.Current.Player.IsEnabled || !Configuration.Current.Player.autoRepair) return;
 
-			if (curr_crafting_station != null)
-			{
-				int repair_count = 0;
+            CraftingStation curr_crafting_station = Player.m_localPlayer.GetCurrentCraftingStation();
 
-				while (__instance.HaveRepairableItems())
-				{
-					__instance.RepairOneItem();
-					++repair_count;
-				}
+            if (curr_crafting_station != null)
+            {
+                int repair_count = 0;
 
-				if (repair_count > 0)
-				{
-					curr_crafting_station.m_repairItemDoneEffects.Create(curr_crafting_station.transform.position, Quaternion.identity, null, 1.0f);
-				}
-			}
-		}
-	}
+                while (__instance.HaveRepairableItems())
+                {
+                    __instance.RepairOneItem();
+                    ++repair_count;
+                }
+
+                if (repair_count > 0)
+                {
+                    curr_crafting_station.m_repairItemDoneEffects.Create(curr_crafting_station.transform.position, Quaternion.identity, null, 1.0f);
+                }
+            }
+        }
+    }
     /*
     /// <summary>
     /// Setting up deconstruct feature
@@ -283,6 +285,9 @@ namespace ValheimPlus.GameClasses
     [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.SetupRequirement))]
     public static class InventoryGui_SetupRequirement_Patch
     {
+        private static Stopwatch delta = new Stopwatch();
+        private static List<Container> nearbyChests = null;
+
         private static bool Prefix(Transform elementRoot, Piece.Requirement req, Player player, bool craft, int quality, ref bool __result)
         {
             Image component = elementRoot.transform.Find("res_icon").GetComponent<Image>();
@@ -308,6 +313,21 @@ namespace ValheimPlus.GameClasses
                     __result = false;
                     return false;
                 }
+
+                if (Configuration.Current.CraftFromChest.IsEnabled)
+                {
+                    int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
+                    if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
+                    {
+                        GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
+                        if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
+
+                        nearbyChests = InventoryAssistant.GetNearbyChests(pos, Helper.Clamp(Configuration.Current.CraftFromChest.range, 1, 50));
+                        delta.Restart();
+                    }
+                    num += InventoryAssistant.GetItemAmountInItemList(InventoryAssistant.GetNearbyChestItemsByContainerList(nearbyChests), req.m_resItem.m_itemData);
+                }
+
                 component3.text = num + "/" + amount.ToString();
 
                 if (num < amount)

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -184,6 +184,10 @@ namespace ValheimPlus
                     }
                 }
             }
+
+            // We don't want to send chest content through network
+            if (totalRemoved == 0) return 0;
+
             allItems.RemoveAll((ItemDrop.ItemData x) => x.m_stack <= 0);
             chest.m_inventory.m_inventory = allItems;
 

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -330,6 +330,7 @@
   <ItemGroup>
     <Compile Include="AdvancedBuildingMode.cs" />
     <Compile Include="AdvancedEditingMode.cs" />
+    <Compile Include="Configurations\Sections\CraftFromChestConfiguration.cs" />
     <Compile Include="Configurations\Sections\FirstPersonConfiguration.cs" />
     <Compile Include="Configurations\Sections\DeconstructConfiguration.cs" />
     <Compile Include="Configurations\Sections\ArmorConfiguration.cs" />
@@ -374,6 +375,7 @@
     <Compile Include="Configurations\Sections\StaminaUsageConfiguration.cs" />
     <Compile Include="Configurations\Sections\StaminaConfiguration.cs" />
     <Compile Include="GameClasses\Container.cs" />
+    <Compile Include="GameClasses\CookingStation.cs" />
     <Compile Include="GameClasses\DropTable.cs" />
     <Compile Include="GameClasses\FejdStartup.cs" />
     <Compile Include="GameClasses\Fireplace.cs" />

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -737,3 +737,24 @@ alignToggle=F7
 
 ; Key to change the default alignment
 changeDefaultAlignment=F6
+
+[CraftFromChest]
+
+; Change false to true tu enable this section
+enabled=true
+
+; If in a workbench area, uses it as reference point when scanning for chests
+; default: true
+checkFromWorkbench=true
+
+; Ignore private area check.
+; default: true
+ignorePrivateAreaCheck=true
+
+; The range of the chest detection (min: 1, max: 50)
+; default: 20
+range=20
+
+; Interval in seconds between each nearby chests discovery (min: 1, max: 10)
+; default: 3
+lookupInterval=3

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -204,6 +204,33 @@
 			}
 		}
 	},
+	"CraftFromChest": {
+		"description": "",
+		"icon": "fa fa-archway",
+		"description_website": "Allows crafting using content of nearby chests.",
+		"entries": {
+			"enabled": {
+				"description": "Change false to true to enable this section",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
+			"checkFromWorkbench": {
+				"description": "If in a workbench area, uses it as reference point when scanning for chests",
+				"defaultValue": "F10",
+				"defaultType": "KeyCode"
+			},
+			"range": {
+				"description": "The range of the chest detection (Maximum is 50)",
+				"defaultValue": "20",
+				"defaultType": "float"
+			},
+			"lookupInterval": {
+				"description": "Interval in seconds between each nearby chests discovery (Maximum is 50)",
+				"defaultValue": "3",
+				"defaultType": "int"
+			}
+		}
+	},
 	"Camera": {
 		"description": "",
 		"icon": "fa fa-video",


### PR DESCRIPTION
This PR adds the possiblity to use chests content through:
- Crafting (hammer and craft stations)
- Adding fuel to fireplaces
- Putting meat on cooking station

Misc:
- Added a missing check in `Container.Aware.Postfix` to prevent calling it on shadowed chests (when crafting)
- Added a missing check in `InventoryAssistant.GetNearbyChests` to ensure a the player have access to the chest (prevent crafting using someone else personal chest)