### PR TITLE
added current level to experience gain notification

### DIFF
--- a/ValheimPlus/GameClasses/Skills.cs
+++ b/ValheimPlus/GameClasses/Skills.cs
@@ -85,7 +85,9 @@ namespace ValheimPlus.GameClasses
 			{
 				Skills.Skill skill = __instance.GetSkill(skillType);
 				float percent = skill.m_accumulator / (skill.GetNextLevelRequirement() / 100);
-				__instance.m_player.Message(MessageHud.MessageType.TopLeft, skill.m_info.m_skill + " [" + Helper.tFloat(skill.m_accumulator, 2) + "/" + Helper.tFloat(skill.GetNextLevelRequirement(), 2) + "] (" + Helper.tFloat(percent, 0) + "%)", 0, skill.m_info.m_icon);
+				__instance.m_player.Message(MessageHud.MessageType.TopLeft, "Level " + Helper.tFloat(skill.m_level, 0) + " " + skill.m_info.m_skill
+					+ " [" + Helper.tFloat(skill.m_accumulator, 2) + "/" + Helper.tFloat(skill.GetNextLevelRequirement(), 2) + "]"
+					+ " (" + Helper.tFloat(percent, 0) + "%)", 0, skill.m_info.m_icon);
 			}
 		}
 	}


### PR DESCRIPTION
Under the HUD Section, there is an option to enable experience gain notification. I think it would be good to add the current level to the notification so we can quickly see what is the current level of skill:

![image](https://user-images.githubusercontent.com/9020992/111074333-dd810080-84b8-11eb-8a37-3856f6305878.png)

Before:
You would only see Jump [Exp] (%)