### PR TITLE
Added: PVP Switch and Skip Intro

### DIFF
--- a/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
@@ -14,5 +14,8 @@
         public float guardianBuffDuration { get; internal set; } = 300;
         public float guardianBuffCooldown { get; internal set; } = 1200;
         public bool autoEquipShield { get; internal set; } = false;
+        public bool pvpveswitch { get; internal set; } = false;
+        public bool pvpveactv { get; internal set; } = false;
+        public bool skipintro { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -686,5 +686,73 @@ namespace ValheimPlus.GameClasses
                 }
             }
         }
-    }    
+    }
+    
+    /// <summary>
+    /// Skip Intro
+    /// </summary>
+    [HarmonyPatch(typeof (Player), "OnSpawned")]
+    public class OnSpawned_Patch
+    {
+        [HarmonyPrefix]
+        internal static void Prefix(Player __instance)
+        {
+            if (Configuration.Current.Player.skipintro)
+            {
+                __instance.m_firstSpawn = false;
+            }
+        }
+    }
+    
+    /// <summary>
+    /// PVP Switch Section
+    /// </summary>
+    [HarmonyPatch(typeof(Player), "SetLocalPlayer")]
+    public static class SetLocalPlayer_Patch
+    {
+        public static void Postfix()
+        {
+            if (Configuration.Current.Player.pvpveactv)
+            {
+                if (Configuration.Current.Player.pvpveswitch)
+                    ZLog.LogWarning("[PVPVE] PVP MODE!");
+                else if (Configuration.Current.Player.pvpveswitch == false)
+                    ZLog.LogWarning("[PVPVE] PVE MODE!");
+                
+                Player.m_localPlayer.SetPVP(Configuration.Current.Player.pvpveswitch);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Player), "CanSwitchPVP")]
+    class CanSwitchPVP_Patch
+    {
+        static bool Prefix(ref bool __result)
+        {
+            if (Configuration.Current.Player.pvpveactv)
+            {
+                __result = !Configuration.Current.Player.pvpveactv;
+                return false;
+            }
+            return true;
+        }
+    }
+    
+    [HarmonyPatch(typeof(Player), "SetPVP")]
+    class SetPVP_Patch
+    {
+        public static bool Prefix(Player __instance)
+        {
+            if (Configuration.Current.Player.pvpveactv)
+            {
+                __instance.m_pvp = Configuration.Current.Player.pvpveswitch;
+                if (Configuration.Current.Player.pvpveswitch)
+                    __instance.m_nview.GetZDO().Set("pvp", __instance.m_pvp);
+                else if (Configuration.Current.Player.pvpveswitch == false)
+                    __instance.m_nview.GetZDO().Set("pve", __instance.m_pvp);
+                return false;
+            }
+            return true;
+        }
+    }
 }

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -442,6 +442,15 @@ guardianBuffCooldown=1200
 ; If set to true, when equipping a one-handed weapon, the best shield from your inventory is automatically equipped. (Best is determined by highest block power)
 autoEquipShield=false
 
+; Change this to true to disable the initial animation of a new player, that "Bird" you bring down to earth.
+skipintro=false
+
+; This is the area that changes the PVP mode, set "pvpveactivator" to false to disable it.
+; Change this to true to enable the PVP Switch section, or to false to disable the PVP Switch section.
+pvpveactv=false
+; [PVP Switch] Change this to true for PVP enabled and to false for PVP disabled.
+pvpveswitch=false
+
 
 [Server]
 


### PR DESCRIPTION
This Pull Request does the addition of two things.

# PVP Switch
PVP Switch is a function that sets PVP to either on or off for all players on the server.
It also prevents them from switching between PVP On and PVP Off mode when it is enabled.

The configuration is simple:
```
; This is the area that changes the PVP mode, set "pvpveactivator" to false to disable it.
; Change this to true to enable the PVP Switch section, or to false to disable the PVP Switch section.
pvpveactv=false
; [PVP Switch] Change this to true for PVP enabled and to false for PVP disabled.
pvpveswitch=false
```

# Skip Intro
This addition causes the introduction of a new character, that "bird" that brings new characters into the world to be removed when activated.

```
; Change this to true to disable the initial animation of a new player, that "Bird" you bring down to earth.
skipintro=false
```