### PR TITLE
Fix autofuel causing FPS drop

### DIFF
--- a/ValheimPlus/GameClasses/CookingStation.cs
+++ b/ValheimPlus/GameClasses/CookingStation.cs
@@ -12,7 +12,6 @@ namespace ValheimPlus.GameClasses
     [HarmonyPatch(typeof(CookingStation), nameof(CookingStation.FindCookableItem))]
     public static class CookingStation_FindCookableItem_Transpiler
     {
-        private static Stopwatch delta = new Stopwatch();
         private static List<Container> nearbyChests = null;
 
         private static MethodInfo method_PullCookableItemFromNearbyChests = AccessTools.Method(typeof(CookingStation_FindCookableItem_Transpiler), nameof(CookingStation_FindCookableItem_Transpiler.PullCookableItemFromNearbyChests));
@@ -55,6 +54,8 @@ namespace ValheimPlus.GameClasses
 
         private static ItemDrop.ItemData PullCookableItemFromNearbyChests(CookingStation station)
         {
+            Stopwatch delta = GameObjectAssistant.GetStopwatch(station.gameObject);
+
             int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
             if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
             {

--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -96,6 +96,11 @@ namespace ValheimPlus.GameClasses
 
                 if (toMaxFuel > 0)
                 {
+                    Stopwatch delta = GameObjectAssistant.GetStopwatch(__instance.gameObject);
+                    
+                    if (delta.IsRunning && delta.ElapsedMilliseconds < 1000) return;
+                    delta.Restart();
+
                     ItemDrop.ItemData fuelItemData = __instance.m_fuelItem.m_itemData;
 
                     int addedFuel = InventoryAssistant.RemoveItemInAmountFromAllNearbyChests(__instance.gameObject, Helper.Clamp(Configuration.Current.FireSource.autoRange, 1, 50), fuelItemData, toMaxFuel, !Configuration.Current.FireSource.ignorePrivateAreaCheck);
@@ -113,7 +118,6 @@ namespace ValheimPlus.GameClasses
     [HarmonyPatch(typeof(Fireplace), nameof(Fireplace.Interact))]
     public static class Fireplace_Interact_Transpiler
     {
-        private static Stopwatch delta = new Stopwatch();
         private static List<Container> nearbyChests = null;
 
         private static MethodInfo method_Inventory_HaveItem = AccessTools.Method(typeof(Inventory), nameof(Inventory.HaveItem));
@@ -153,6 +157,7 @@ namespace ValheimPlus.GameClasses
         {
             if (inventory.HaveItem(item.m_shared.m_name)) return true; // original code
 
+            Stopwatch delta = GameObjectAssistant.GetStopwatch(fireplace.gameObject);
             int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
             if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
             {

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -285,7 +285,6 @@ namespace ValheimPlus.GameClasses
     [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.SetupRequirement))]
     public static class InventoryGui_SetupRequirement_Patch
     {
-        private static Stopwatch delta = new Stopwatch();
         private static List<Container> nearbyChests = null;
 
         private static bool Prefix(Transform elementRoot, Piece.Requirement req, Player player, bool craft, int quality, ref bool __result)
@@ -316,12 +315,13 @@ namespace ValheimPlus.GameClasses
 
                 if (Configuration.Current.CraftFromChest.IsEnabled)
                 {
+                    GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
+                    if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
+
+                    Stopwatch delta = GameObjectAssistant.GetStopwatch(pos.gameObject);
                     int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
                     if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
                     {
-                        GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
-                        if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
-
                         nearbyChests = InventoryAssistant.GetNearbyChests(pos, Helper.Clamp(Configuration.Current.CraftFromChest.range, 1, 50));
                         delta.Restart();
                     }

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -768,7 +768,6 @@ namespace ValheimPlus.GameClasses
     [HarmonyPatch(typeof(Player), nameof(Player.HaveRequirements), new System.Type[] { typeof(Piece.Requirement[]), typeof(bool), typeof(int) })]
     public static class Player_HaveRequirements_Transpiler
     {
-        private static Stopwatch delta = new Stopwatch();
         private static List<Container> nearbyChests = null;
 
         private static MethodInfo method_Inventory_CountItems = AccessTools.Method(typeof(Inventory), nameof(Inventory.CountItems));
@@ -800,12 +799,13 @@ namespace ValheimPlus.GameClasses
 
         private static int ComputeItemQuantity(int fromInventory, Piece.Requirement item, Player player)
         {
+            GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
+            if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
+            
+            Stopwatch delta = GameObjectAssistant.GetStopwatch(pos.gameObject);
             int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
             if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
             {
-                GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
-                if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
-
                 nearbyChests = InventoryAssistant.GetNearbyChests(pos, Helper.Clamp(Configuration.Current.CraftFromChest.range, 1, 50), !Configuration.Current.CraftFromChest.ignorePrivateAreaCheck);
                 delta.Restart();
             }
@@ -816,7 +816,6 @@ namespace ValheimPlus.GameClasses
     [HarmonyPatch(typeof(Player), nameof(Player.HaveRequirements), new System.Type[] { typeof(Piece), typeof(Player.RequirementMode) })]
     public static class Player_HaveRequirements_2_Transpiler
     {
-        private static Stopwatch delta = new Stopwatch();
         private static List<Container> nearbyChests = null;
 
         private static MethodInfo method_Inventory_CountItems = AccessTools.Method(typeof(Inventory), nameof(Inventory.CountItems));
@@ -848,12 +847,13 @@ namespace ValheimPlus.GameClasses
 
         private static int ComputeItemQuantity(int fromInventory, Piece.Requirement item, Player player)
         {
+            GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
+            if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
+
+            Stopwatch delta = GameObjectAssistant.GetStopwatch(pos.gameObject);
             int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
             if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
             {
-                GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
-                if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
-
                 nearbyChests = InventoryAssistant.GetNearbyChests(pos, Helper.Clamp(Configuration.Current.CraftFromChest.range, 1, 50), !Configuration.Current.CraftFromChest.ignorePrivateAreaCheck);
                 delta.Restart();
             }

--- a/ValheimPlus/Utility/GameObjectAssistant.cs
+++ b/ValheimPlus/Utility/GameObjectAssistant.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using System.Diagnostics;
+
+namespace ValheimPlus
+{
+    static class GameObjectAssistant
+    {
+        private static ConcurrentDictionary<float, Stopwatch> stopwatches = new ConcurrentDictionary<float, Stopwatch>();
+
+        public static Stopwatch GetStopwatch(GameObject o)
+        {
+            float hash = GetGameObjectPosHash(o);
+            Stopwatch stopwatch = null;
+
+            if (!stopwatches.TryGetValue(hash, out stopwatch))
+            {
+                stopwatch = new Stopwatch();
+                stopwatches.TryAdd(hash, stopwatch);
+            }
+
+            return stopwatch;
+        }
+
+        private static float GetGameObjectPosHash(GameObject o)
+        {
+            return (1000f * o.transform.position.x) + o.transform.position.y + (.001f * o.transform.position.z);
+        }
+    }
+}

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -137,7 +137,7 @@ namespace ValheimPlus
             int availableAmount = GetItemAmountInItemList(allItems, needle);
 
             // check if there are enough items
-            if (availableAmount < amount || amount == 0)
+            if (amount == 0)
                 return 0;
 
             // iterate all chests and remove as many items as possible for the respective chest
@@ -204,6 +204,5 @@ namespace ValheimPlus
             c.Save();
             c.GetInventory().Changed();
         }
-
     }
 }

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -388,6 +388,7 @@
     <Compile Include="GameClasses\TeleportWorld.cs" />
     <Compile Include="GameClasses\Humanoid.cs" />
     <Compile Include="RPC\VPlusAck.cs" />
+    <Compile Include="Utility\GameObjectAssistant.cs" />
     <Compile Include="Utility\InventoryAssistant.cs" />
     <Compile Include="Utility\ListExtensions.cs" />
     <Compile Include="Utility\RPCQueue.cs" />


### PR DESCRIPTION
Introduced with previous PR, the autoFuel feature would provoc FPS drop when many smelters objects present were present in the scene.

To avoid this, I added a static map of `Stopwatch` where the key is the computed value of the GameObject transformation Vector3.

Hash collision _could_ technically happen but due to the way GameObjects are loaded/unloaded from the scene, it should not happen.

Tested with 50 smelters in the same zone.