### PR TITLE
Disable water force damage to boats.

### DIFF
--- a/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
@@ -9,5 +9,6 @@
         public bool disableStructuralIntegrity { get; set; } = false;
         public bool disableDamageToPlayerStructures { get; set; } = false;
         public bool disableDamageToPlayerBoats { get; set; } = false;
+        public bool disableWaterDamageToPlayerBoats { get; set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/WearNTear.cs
+++ b/ValheimPlus/GameClasses/WearNTear.cs
@@ -50,8 +50,14 @@ namespace ValheimPlus.GameClasses
                 return true;
 
             if (__instance.m_piece.m_name.StartsWith("$ship"))
-                return !Configuration.Current.StructuralIntegrity.disableDamageToPlayerBoats;
-
+            {
+	            if (Configuration.Current.StructuralIntegrity.disableDamageToPlayerBoats ||
+	                (Configuration.Current.StructuralIntegrity.disableWaterDamageToPlayerBoats &&
+	                 stackTrace.GetFrame(15).GetMethod().Name == "UpdateWaterForce")) return false;
+	            
+	            return true;
+            }
+            
             return !Configuration.Current.StructuralIntegrity.disableDamageToPlayerStructures;
         }
 	}

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -576,6 +576,9 @@ disableDamageToPlayerStructures=false
 ; Disables any damage from anything to all player built boats
 disableDamageToPlayerBoats=false
 
+; Disables water force damage to all player built boats
+disableWaterDamageToPlayerBoats=false
+
 ; Each of these values reduce the loss of structural integrity by distance by % less. The value 100 would result in disabled structural integrity and allow placement in free air.
 wood=0
 stone=0

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -1243,6 +1243,11 @@
 				"defaultValue": "false",
 				"defaultType": "bool"
 			},
+			"disableWaterDamageToPlayerBoats": {
+				"description": "Disables water force damage to all player built boats",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
 			"wood": {
 				"description": "Each of these values reduce the loss of structural integrity by distance by %.",
 				"defaultValue": "0",


### PR DESCRIPTION
Hi, love your work.

My tribe wanted the ability to disable only the lag damage that our boats receive just from sailing around but still be threatened by sea monsters or destroy boats ourselves if need be. This update hopefully achieves that.