### PR TITLE
Fix CraftFromChest causing FPS drop

### DIFF
--- a/ValheimPlus/GameClasses/Inventory.cs
+++ b/ValheimPlus/GameClasses/Inventory.cs
@@ -1,5 +1,7 @@
-using System;
 using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using UnityEngine;
 using ValheimPlus.Configurations;
 
@@ -59,5 +61,11 @@ namespace ValheimPlus.GameClasses
                 }
             }
         }
+    }
+
+    public static class Inventory_NearbyChests_Cache
+    {
+        public static List<Container> chests = new List<Container>();
+        public static readonly Stopwatch delta = new Stopwatch();
     }
 }

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -1,8 +1,8 @@
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using UnityEngine;
@@ -285,8 +285,6 @@ namespace ValheimPlus.GameClasses
     [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.SetupRequirement))]
     public static class InventoryGui_SetupRequirement_Patch
     {
-        private static List<Container> nearbyChests = null;
-
         private static bool Prefix(Transform elementRoot, Piece.Requirement req, Player player, bool craft, int quality, ref bool __result)
         {
             Image component = elementRoot.transform.Find("res_icon").GetComponent<Image>();
@@ -315,17 +313,24 @@ namespace ValheimPlus.GameClasses
 
                 if (Configuration.Current.CraftFromChest.IsEnabled)
                 {
-                    GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
-                    if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench) pos = player.gameObject;
+                    Stopwatch delta;
 
-                    Stopwatch delta = GameObjectAssistant.GetStopwatch(pos.gameObject);
+                    GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
+                    if (!pos || !Configuration.Current.CraftFromChest.checkFromWorkbench)
+                    {
+                        pos = player.gameObject;
+                        delta = Inventory_NearbyChests_Cache.delta;
+                    }
+                    else
+                        delta = GameObjectAssistant.GetStopwatch(pos);
+
                     int lookupInterval = Helper.Clamp(Configuration.Current.CraftFromChest.lookupInterval, 1, 10) * 1000;
                     if (!delta.IsRunning || delta.ElapsedMilliseconds > lookupInterval)
                     {
-                        nearbyChests = InventoryAssistant.GetNearbyChests(pos, Helper.Clamp(Configuration.Current.CraftFromChest.range, 1, 50));
+                        Inventory_NearbyChests_Cache.chests = InventoryAssistant.GetNearbyChests(pos, Helper.Clamp(Configuration.Current.CraftFromChest.range, 1, 50));
                         delta.Restart();
                     }
-                    num += InventoryAssistant.GetItemAmountInItemList(InventoryAssistant.GetNearbyChestItemsByContainerList(nearbyChests), req.m_resItem.m_itemData);
+                    num += InventoryAssistant.GetItemAmountInItemList(InventoryAssistant.GetNearbyChestItemsByContainerList(Inventory_NearbyChests_Cache.chests), req.m_resItem.m_itemData);
                 }
 
                 component3.text = num + "/" + amount.ToString();

--- a/ValheimPlus/Utility/GameObjectAssistant.cs
+++ b/ValheimPlus/Utility/GameObjectAssistant.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Text;
-using UnityEngine;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
+using UnityEngine;
 
 namespace ValheimPlus
 {

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using UnityEngine;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Collections.Generic;
-using System.IO;
+using UnityEngine;
 
 
 namespace ValheimPlus
@@ -28,7 +25,7 @@ namespace ValheimPlus
                 {
                     Container foundContainer = hitCollider.GetComponentInParent<Container>();
                     bool hasAccess = foundContainer.CheckAccess(Player.m_localPlayer.GetPlayerID());
-                    if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(target.transform.position, flash: false);
+                    if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(target.transform.position, 0f, false, true);
                     if (foundContainer.m_name.Contains("piece_chest") && hasAccess && foundContainer.GetInventory() != null)
                     {
                         validContainers.Add(foundContainer);


### PR DESCRIPTION
Reworked the way the CraftFromChest feature is handled to use a caching system when bases on the player position to avoid heavy performance impact. This should now be almost transparent.

Also took into account the changes made on the `PrivateArea.CheckAccess` function with today's game update.