### PR TITLE
Fix fireplaces not staying at max fuel

### DIFF
--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -1,11 +1,10 @@
 ﻿using HarmonyLib;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using UnityEngine;
 using ValheimPlus.Configurations;
 
 namespace ValheimPlus.GameClasses
@@ -16,22 +15,21 @@ namespace ValheimPlus.GameClasses
         public static class Fireplace_Awake_Patch
         {
             /// <summary>
-            /// When fire source is created, check for configurations and set its start fuel to max fuel
+            /// When fire source is loaded in view, check for configurations and set its start fuel and current fuel to max fuel
             /// </summary>
-            private static void Prefix(ref Fireplace __instance)
+            private static void Postfix(ref Fireplace __instance, ref ZNetView __m_nview)
             {
                 if (!Configuration.Current.FireSource.IsEnabled) return;
 
-                if (FireplaceExtensions.IsTorch(__instance.m_name))
+                if (Configuration.Current.FireSource.torches && FireplaceExtensions.IsTorch(__instance.m_name))
                 {
-                    if (Configuration.Current.FireSource.torches)
-                    {
-                        __instance.m_startFuel = __instance.m_maxFuel;
-                    }
+                    __instance.m_startFuel = __instance.m_maxFuel;
+                    __m_nview.GetZDO().Set("fuel", __instance.m_maxFuel);
                 }
                 else if (Configuration.Current.FireSource.fires)
                 {
                     __instance.m_startFuel = __instance.m_maxFuel;
+                    __m_nview.GetZDO().Set("fuel", __instance.m_maxFuel);
                 }
             }
         }
@@ -97,7 +95,7 @@ namespace ValheimPlus.GameClasses
                 if (toMaxFuel > 0)
                 {
                     Stopwatch delta = GameObjectAssistant.GetStopwatch(__instance.gameObject);
-                    
+
                     if (delta.IsRunning && delta.ElapsedMilliseconds < 1000) return;
                     delta.Restart();
 


### PR DESCRIPTION
Changed `Prefix` to `Postfix` hook for Fireplace.Awake since we need to wait until the Fireplace object has been instantiated.

Also adds a missing set of current fuel quantity to the max.

See #436 