### PR TITLE
Add ability to queue weapon changes mid-attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,3 +368,4 @@ Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for details on compiling V+ for d
 * Zogniton - https://github.com/Zogniton - Inventory Overhaul initial creator
 * Jules - https://github.com/sirskunkalot
 * Lilian Cahuzac - https://github.com/healiha
+* Thomas 'Aeluwas#2855' B. - https://github.com/exscape

--- a/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
@@ -17,5 +17,6 @@
         public bool autoEquipShield { get; internal set; } = false;
         public bool skipIntro { get; internal set; } = false;
         public bool iHaveArrivedOnSpawn { get; internal set; } = false;
+        public bool queueWeaponChanges { get; internal set; } = false;
     }
 }

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -506,6 +506,9 @@ disableGuardianBuffAnimation=false
 ; If set to true, when equipping a one-handed weapon, the best shield from your inventory is automatically equipped. (Best is determined by highest block power)
 autoEquipShield=false
 
+; If set to true, weapon switches requested mid-attack will be carried out when the current attack is finished (instead of being ignored)
+queueWeaponChanges=false
+
 ; If set to true, you will always skip the intro of the game.
 skipIntro=false
 

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -1054,13 +1054,18 @@
 				"defaultValue": "false",
 				"defaultType": "bool"
 			},
+			"queueWeaponChanges": {
+				"description": "If set to true, weapon switches requested mid-attack will be carried out when the current attack is finished (instead of being ignored)",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
 			"skipIntro": {
 				"description": "If set to true, you will always skip the intro of the game.",
 				"defaultValue": "false",
 				"defaultType": "bool"
 			},
 			"iHaveArrivedOnSpawn": {
-				"description": "If set to false, disables the "I have arrived!" message on player spawn.",
+				"description": "If set to false, disables the \"I have arrived!\" message on player spawn.",
 				"defaultValue": "false",
 				"defaultType": "bool"
 			}


### PR DESCRIPTION
When attempting to switch weapons in the middle of a fight, the game will by default
simply ignore your request if you're currently attacking.
This patch allows to queue them and switch ASAP when the attack is finished.
Supports swiching to multiple items, e.g. sword and shield.

Also queues hiding weapons (default R) if pressed mid-attack.