### PR TITLE
Kiln fuel protection & Beehive autoDeposit without interaction

### DIFF
--- a/README.bbcode
+++ b/README.bbcode
@@ -125,7 +125,9 @@ A HarmonyX Mod aimed at improving the gameplay quality of Valheim. The mod inclu
 [list]
 [*] Modify Kiln, Furnace and Blast Furnace processing speed.
 [*] Modify Kiln, Furnace and Blast Furnace maximum capacity.
+[*] Disable Fine Wood and/or Round Log processing for Kiln.
 [*] Allow fuel-type items to be automatically pulled from closest containers.
+[*] Allow Kiln to stop pulling wood from closest containers when a specific threshold as been reached.
 [*] Allow items produced by Kiln, Furnace and Blast Furnace to be automatically placed in the closest containers.
 [/list]
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ We work together closely to make sure all our features are integrated and workin
 ### Kiln, Furnace and Blast Furnace
 * Modify Kiln, Furnace and Blast Furnace processing speed.
 * Modify Kiln, Furnace and Blast Furnace maximum capacity.
+* Disable Fine Wood and/or Round Log processing for Kiln.
 * Allow fuel-type items to be automatically pulled from closest containers.
+* Allow Kiln to stop pulling wood from closest containers when a specific threshold as been reached. 
 * Allow items produced by Kiln, Furnace and Blast Furnace to be automatically placed in the closest containers.
 
 ### Beehive 

--- a/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
@@ -4,8 +4,11 @@
     {
         public float productionSpeed { get; internal set; } = 10;
         public int maximumWood { get; internal set; } = 25;
+        public bool dontProcessFineWood { get; internal set; } = false;
+        public bool dontProcessRoundLog { get; internal set; } = false;
         public bool autoDeposit { get; internal set; } = false;
         public bool autoFuel { get; internal set; } = false;
+        public int stopAutoFuelThreshold { get; internal set; } = 0;
         public bool ignorePrivateAreaCheck { get; internal set; } = true;
         public float autoRange { get; internal set; } = 10;
     }

--- a/ValheimPlus/GameClasses/Beehive.cs
+++ b/ValheimPlus/GameClasses/Beehive.cs
@@ -1,8 +1,10 @@
 using HarmonyLib;
-using ValheimPlus.Configurations;
-using UnityEngine;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+using ValheimPlus.Configurations;
 
 namespace ValheimPlus.GameClasses
 {
@@ -85,8 +87,8 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Auto Deposit for Beehives
     /// </summary>
-    [HarmonyPatch(typeof(Beehive), "RPC_Extract")]
-    public static class Beehive_UpdateBees_Patch
+    [HarmonyPatch(typeof(Beehive), nameof(Beehive.RPC_Extract))]
+    public static class Beehive_RPC_Extract_Patch
     {
         private static bool Prefix(long caller, ref Beehive __instance)
         {
@@ -100,14 +102,10 @@ namespace ValheimPlus.GameClasses
             if (__instance.GetHoneyLevel() <= 0)
                 return true;
 
-            if (Configuration.Current.Beehive.autoDepositRange > 50)
-                Configuration.Current.Beehive.autoDepositRange = 50;
-
-            if (Configuration.Current.Beehive.autoDepositRange < 1)
-                Configuration.Current.Beehive.autoDepositRange = 1;
+            float autoDepositRange = Helper.Clamp(Configuration.Current.Beehive.autoDepositRange, 1, 50);
 
             // find nearby chests
-            List<Container> nearbyChests = InventoryAssistant.GetNearbyChests(beehive.gameObject, Configuration.Current.Beehive.autoDepositRange);
+            List<Container> nearbyChests = InventoryAssistant.GetNearbyChests(beehive.gameObject, autoDepositRange);
             if (nearbyChests.Count == 0)
                 return true;
 
@@ -116,14 +114,14 @@ namespace ValheimPlus.GameClasses
                 GameObject itemPrefab = ObjectDB.instance.GetItemPrefab(__instance.m_honeyItem.gameObject.name);
 
                 ZNetView.m_forceDisableInit = true;
-                GameObject honeyObject = UnityEngine.Object.Instantiate<GameObject>(itemPrefab);
+                GameObject honeyObject = Object.Instantiate<GameObject>(itemPrefab);
                 ZNetView.m_forceDisableInit = false;
 
                 ItemDrop comp = honeyObject.GetComponent<ItemDrop>();
 
                 bool result = spawnNearbyChest(comp, true);
-                UnityEngine.Object.Destroy(honeyObject);
-                
+                Object.Destroy(honeyObject);
+
                 if (!result)
                 {
                     // Couldn't drop in chest, letting original code handle things
@@ -151,7 +149,7 @@ namespace ValheimPlus.GameClasses
                     InventoryAssistant.ConveyContainerToNetwork(chest);
                     return true;
                 }
-                
+
                 if (mustHaveItem)
                     return spawnNearbyChest(item, false);
 
@@ -159,6 +157,84 @@ namespace ValheimPlus.GameClasses
             }
 
             return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(Beehive), nameof(Beehive.UpdateBees))]
+    public static class Beehive_UpdateBees_Transpiler
+    {
+        private static MethodInfo method_AutoDepositToChest = AccessTools.Method(typeof(Beehive_UpdateBees_Transpiler), nameof(Beehive_UpdateBees_Transpiler.AutoDepositToChest));
+
+        /// <summary>
+        /// Patches out the code that periodically updates the amount of honey in a beehive.
+        /// When beehive is full, drops the honey to the nearby chests.
+        /// </summary>
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            if (!Configuration.Current.Beehive.IsEnabled || !Configuration.Current.Beehive.autoDeposit) return instructions;
+
+            List<CodeInstruction> il = instructions.ToList();
+
+            int i = il.Count - 2;
+            il.Insert(++i, new CodeInstruction(OpCodes.Ldarga, 0));
+            il.Insert(++i, new CodeInstruction(OpCodes.Call, method_AutoDepositToChest));
+
+            return il.AsEnumerable();
+        }
+
+        private static void AutoDepositToChest(ref Beehive __instance)
+        {
+            Beehive beehive = __instance;
+
+            List<Container> nearbyChests = InventoryAssistant.GetNearbyChests(beehive.gameObject, Helper.Clamp(Configuration.Current.Beehive.autoDepositRange, 1, 50));
+
+            while (beehive.GetHoneyLevel() > 0)
+            {
+                GameObject itemPrefab = ObjectDB.instance.GetItemPrefab(beehive.m_honeyItem.gameObject.name);
+
+                ZNetView.m_forceDisableInit = true;
+                GameObject honeyObject = Object.Instantiate<GameObject>(itemPrefab);
+                ZNetView.m_forceDisableInit = false;
+
+                ItemDrop comp = honeyObject.GetComponent<ItemDrop>();
+
+                bool result = spawnNearbyChest(comp, true);
+                Object.Destroy(honeyObject);
+
+                if (!result)
+                {
+                    // Couldn't drop in chest, letting original code handle things
+                    return;
+                }
+            }
+
+            if (beehive.GetHoneyLevel() == 0)
+                beehive.m_spawnEffect.Create(beehive.m_spawnPoint.position, Quaternion.identity);
+
+            bool spawnNearbyChest(ItemDrop item, bool mustHaveItem)
+            {
+                foreach (Container chest in nearbyChests)
+                {
+                    Inventory cInventory = chest.GetInventory();
+                    if (mustHaveItem && !cInventory.HaveItem(item.m_itemData.m_shared.m_name))
+                        continue;
+
+                    if (!cInventory.AddItem(item.m_itemData))
+                    {
+                        //Chest full, move to the next
+                        continue;
+                    }
+                    beehive.m_nview.GetZDO().Set("level", beehive.GetHoneyLevel() - 1);
+                    InventoryAssistant.ConveyContainerToNetwork(chest);
+                    return true;
+                }
+
+                if (mustHaveItem)
+                    return spawnNearbyChest(item, false);
+
+                return false;
+            }
         }
     }
 }

--- a/ValheimPlus/GameClasses/Inventory.cs
+++ b/ValheimPlus/GameClasses/Inventory.cs
@@ -63,51 +63,51 @@ namespace ValheimPlus.GameClasses
         }
     }
 
-  
-  public static class Inventory_NearbyChests_Cache
+
+    public static class Inventory_NearbyChests_Cache
     {
         public static List<Container> chests = new List<Container>();
         public static readonly Stopwatch delta = new Stopwatch();
     }
 
-	/// <summary>
-	/// When merging another inventory, try to merge items with existing stacks.
-	/// </summary>
-	[HarmonyPatch(typeof(Inventory), "MoveAll")]
-	public static class Inventory_MoveAll_Patch
-	{
-		private static void Prefix(ref Inventory __instance, ref Inventory fromInventory)
-		{
-			if (Configuration.Current.Inventory.IsEnabled && Configuration.Current.Inventory.mergeWithExistingStacks)
-			{
-				List<ItemDrop.ItemData> list = new List<ItemDrop.ItemData>(fromInventory.GetAllItems());
-				foreach (ItemDrop.ItemData otherItem in list)
-				{
-					if (otherItem.m_shared.m_maxStackSize > 1)
-					{
-						foreach (ItemDrop.ItemData myItem in __instance.m_inventory)
-						{
-							if (myItem.m_shared.m_name == otherItem.m_shared.m_name && myItem.m_quality == otherItem.m_quality)
-							{
-								int itemsToMove = Math.Min(myItem.m_shared.m_maxStackSize - myItem.m_stack, otherItem.m_stack);
-								myItem.m_stack += itemsToMove;
-								if (otherItem.m_stack == itemsToMove)
-								{
-									fromInventory.RemoveItem(otherItem);
-									break;
-								}
-								else
-								{
-									otherItem.m_stack -= itemsToMove;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+    /// <summary>
+    /// When merging another inventory, try to merge items with existing stacks.
+    /// </summary>
+    [HarmonyPatch(typeof(Inventory), "MoveAll")]
+    public static class Inventory_MoveAll_Patch
+    {
+        private static void Prefix(ref Inventory __instance, ref Inventory fromInventory)
+        {
+            if (Configuration.Current.Inventory.IsEnabled && Configuration.Current.Inventory.mergeWithExistingStacks)
+            {
+                List<ItemDrop.ItemData> list = new List<ItemDrop.ItemData>(fromInventory.GetAllItems());
+                foreach (ItemDrop.ItemData otherItem in list)
+                {
+                    if (otherItem.m_shared.m_maxStackSize > 1)
+                    {
+                        foreach (ItemDrop.ItemData myItem in __instance.m_inventory)
+                        {
+                            if (myItem.m_shared.m_name == otherItem.m_shared.m_name && myItem.m_quality == otherItem.m_quality)
+                            {
+                                int itemsToMove = Math.Min(myItem.m_shared.m_maxStackSize - myItem.m_stack, otherItem.m_stack);
+                                myItem.m_stack += itemsToMove;
+                                if (otherItem.m_stack == itemsToMove)
+                                {
+                                    fromInventory.RemoveItem(otherItem);
+                                    break;
+                                }
+                                else
+                                {
+                                    otherItem.m_stack -= itemsToMove;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-    
+
 
 }

--- a/ValheimPlus/ValheimPlus.cs
+++ b/ValheimPlus/ValheimPlus.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using BepInEx;
+using HarmonyLib;
+using System;
 using System.IO;
 using System.Net;
-using BepInEx;
-using HarmonyLib;
 using ValheimPlus.Configurations;
 using ValheimPlus.RPC;
 using ValheimPlus.UI;
@@ -12,7 +11,7 @@ namespace ValheimPlus
 {
     // COPYRIGHT 2021 KEVIN "nx#8830" J. // http://n-x.xyz
     // GITHUB REPOSITORY https://github.com/valheimPlus/ValheimPlus
-    
+
 
     [BepInPlugin("org.bepinex.plugins.valheim_plus", "Valheim Plus", version)]
     public class ValheimPlusPlugin : BaseUnityPlugin
@@ -46,7 +45,7 @@ namespace ValheimPlus
             {
                 Logger.LogInfo("Configuration file loaded succesfully.");
 
-                
+
                 harmony.PatchAll();
 
                 isUpToDate = !IsNewVersionAvailable();
@@ -64,7 +63,7 @@ namespace ValheimPlus
                 if (!Directory.Exists(VPlusDataDirectoryPath)) Directory.CreateDirectory(VPlusDataDirectoryPath);
 
                 //Logo
-                if(Configuration.Current.ValheimPlus.IsEnabled && Configuration.Current.ValheimPlus.mainMenuLogo)
+                if (Configuration.Current.ValheimPlus.IsEnabled && Configuration.Current.ValheimPlus.mainMenuLogo)
                     VPlusMainMenu.Load();
 
                 //Map Sync Save Timer
@@ -111,7 +110,7 @@ namespace ValheimPlus
                     return true;
                 }
             }
-            
+
             return false;
         }
     }

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -421,6 +421,12 @@ enabled=false
 ; Maximum amount of wood in a Kiln
 maximumWood=25
 
+; Change false to true to disable Fine Wood processing.
+dontProcessFineWood=false
+
+; Change false to true to disabled Round Log processing.
+dontProcessRoundLog=false
+
 ; The time it takes for the Kiln to produce a single piece of coal in seconds.
 productionSpeed=30
 
@@ -429,6 +435,9 @@ autoDeposit=false
 
 ; Look for fuel inside nearby chests.
 autoFuel=false
+
+; Stop looking for fuel when there is at leasts this quantity of Coal in nearby chests (ignored if set to 0)
+stopAutoFuelThreshold=0
 
 ; Ignore private area check.
 ; default: true

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -919,6 +919,16 @@
 				"defaultValue": "25",
 				"defaultType": "int"
 			},
+			"dontProcessFineWood": {
+				"description": "Disable Fine Wood as a ressource",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
+			"dontProcessRoundLog": {
+				"description": "Disable Round Log as a ressource",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
 			"productionSpeed": {
 				"description": "The time it takes for the Kiln to produce a single piece of coal in seconds.",
 				"defaultValue": "30",
@@ -933,6 +943,11 @@
 				"description": "Look for fuel inside nearby chests",
 				"defaultValue": "false",
 				"defaultType": "bool"
+			},
+			"stopAutoFuelThreshold": {
+				"description": "Stop looking for fuel when there is at leasts this quantity of Coal in nearby chests (ignored if set to 0)",
+				"defaultValue": "0",
+				"defaultType": "int"
 			},
 			"ignorePrivateAreaCheck": {
 				"description": "Change true to false to enable private area check when looking for chests.",


### PR DESCRIPTION
Gives the possibility to prevent Kiln from processing Fine Wood & Round Log.

Beehive now autoDeposit in nearby chests without interaction. If chests are full, honey is left in in the beehive.