### PR TITLE
Fix item disposal

### DIFF
--- a/ValheimPlus/Configurations/Sections/ItemsConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ItemsConfiguration.cs
@@ -2,9 +2,9 @@
 {
     public class ItemsConfiguration : ServerSyncConfig<ItemsConfiguration>
     {
-        public bool noTeleportPrevention { get; set; } = false;
-        public float baseItemWeightReduction { get; set; } = 0;
+        public bool noTeleportPrevention { get; internal set; } = false;
+        public float baseItemWeightReduction { get; internal set; } = 0;
         public float itemStackMultiplier { get; internal set; } = 1;
-        public int droppedItemOnGroundDurationInSeconds { get; internal set; } = 3600;
+        public float droppedItemOnGroundDurationInSeconds { get; internal set; } = 3600;
     }
 }


### PR DESCRIPTION
Changed the method used to set the time before an item should be destroyed when lying on the ground.

The previous method wasn't fail proof as it would throw errors on newly created servers due to the way the instance time is computed.