### PR TITLE
Allow re-equipping of items after swimming

### DIFF
--- a/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
@@ -18,5 +18,6 @@
         public bool skipIntro { get; internal set; } = false;
         public bool iHaveArrivedOnSpawn { get; internal set; } = true;
         public bool queueWeaponChanges { get; internal set; } = false;
+        public bool reequipItemsAfterSwimming { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/Humanoid.cs
+++ b/ValheimPlus/GameClasses/Humanoid.cs
@@ -72,4 +72,37 @@ namespace ValheimPlus.GameClasses
             return __result;
         }
     }
+
+    public static class UpdateEquipmentState
+    {
+        public static bool shouldReequipItemsAfterSwimming = false;
+    }
+
+    [HarmonyPatch(typeof(Humanoid), "UpdateEquipment")]
+    public static class Humanoid_UpdateEquipment_Patch
+    {
+        private static bool Prefix(Humanoid __instance)
+        {
+            if (!Configuration.Current.Player.IsEnabled || !Configuration.Current.Player.reequipItemsAfterSwimming)
+                return true;
+
+            if (__instance.IsPlayer() && __instance.IsSwiming() && !__instance.IsOnGround())
+            {
+                // The above is only enough to know we will eventually exit swimming, but we still don't know if the items were visible prior or not.
+                // We only want to re-show them if they were shown to begin with, so we need to check.
+                // This is also why this must be a prefix patch; in a postfix patch, the items are already hidden, and we don't know
+                // if they were hidden by UpdateEquipment or by the user far earlier.
+
+                if (__instance.m_leftItem != null || __instance.m_rightItem != null)
+                    UpdateEquipmentState.shouldReequipItemsAfterSwimming = true;
+            }
+            else if (__instance.IsPlayer() && !__instance.IsSwiming() && __instance.IsOnGround() && UpdateEquipmentState.shouldReequipItemsAfterSwimming)
+            {
+                __instance.ShowHandItems();
+                UpdateEquipmentState.shouldReequipItemsAfterSwimming = false;
+            }
+
+            return true;
+        }
+    }
 }

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -511,6 +511,9 @@ skipIntro=false
 ; If set to false, disables the "I have arrived!" message on player spawn.
 iHaveArrivedOnSpawn=true
 
+; If set to true, items will be re-equipped when you exit water after swimming (if they were hidden automatically)
+reequipItemsAfterSwimming=false
+
 [Server]
 
 ; Change false to true to enable this section

--- a/vplusSuggestions/todo.json
+++ b/vplusSuggestions/todo.json
@@ -90,12 +90,6 @@
 	"progress": "70",
     "category": "General"
   },
-  "Auto weapon switch after swimming": {
-    "description": "Add the ability to auto equip the weapons you were holding before you entered water.",
-    "icon": "fas fa-mace",
-    "status": "In Consideration",
-    "category": "Player"
-  },
   "Bow Ammo": {
     "description": "Show the arrow count in some way when the bow is equipped. <a target='_blank' href='https://github.com/valheimPlus/ValheimPlus/issues/210'>reference</a>",
     "icon": "fa fa-bow-arrow",

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -1068,6 +1068,11 @@
 				"description": "If set to false, disables the \"I have arrived!\" message on player spawn.",
 				"defaultValue": "true",
 				"defaultType": "bool"
+			},
+			"reequipItemsAfterSwimming": {
+				"description": "If set to true, items will be re-equipped when you exit water after swimming (if they were hidden automatically)",
+				"defaultValue": "false",
+				"defaultType": "bool"
 			}
 		}
 	},


### PR DESCRIPTION
If you were holding items when entering the water, this will re-equip them as you exit.