### PR TITLE
add skip tutorials mod. skip intro already exist

### DIFF
--- a/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PlayerConfiguration.cs
@@ -19,5 +19,6 @@
         public bool iHaveArrivedOnSpawn { get; internal set; } = true;
         public bool queueWeaponChanges { get; internal set; } = false;
         public bool reequipItemsAfterSwimming { get; internal set; } = false;
+        public bool skipTutorials { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -1023,7 +1023,7 @@ namespace ValheimPlus.GameClasses
     /// skip all tutorials from now on
     /// </summary>
     [HarmonyPatch(typeof(Player), "HaveSeenTutorial")]
-    public class HaveSeenTutorial_Patch
+    public class Player_HaveSeenTutorial_Patch
     {
         [HarmonyPrefix]
         internal static void Prefix(Player __instance, ref string name)

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -1018,4 +1018,23 @@ namespace ValheimPlus.GameClasses
             }
         }
     }
+
+    /// <summary>
+    /// skip all tutorials from now on
+    /// </summary>
+    [HarmonyPatch(typeof(Player), "HaveSeenTutorial")]
+    public class HaveSeenTutorial_Patch
+    {
+        [HarmonyPrefix]
+        internal static void Prefix(Player __instance, ref string name)
+        {
+            if (Configuration.Current.Player.IsEnabled && Configuration.Current.Player.skipTutorials)
+            {
+                if (!__instance.m_shownTutorials.Contains(name))
+                {
+                    __instance.m_shownTutorials.Add(name);
+                }
+            }
+        }
+    }
 }

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -1026,7 +1026,7 @@ namespace ValheimPlus.GameClasses
     public class Player_HaveSeenTutorial_Patch
     {
         [HarmonyPrefix]
-        internal static void Prefix(Player __instance, ref string name)
+        private static void Prefix(Player __instance, ref string name)
         {
             if (Configuration.Current.Player.IsEnabled && Configuration.Current.Player.skipTutorials)
             {

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -523,9 +523,6 @@ iHaveArrivedOnSpawn=true
 ; If set to true, items will be re-equipped when you exit water after swimming (if they were hidden automatically)
 reequipItemsAfterSwimming=false
 
-; If set to true, all tutorial will skip from now on. You can turn it off and reset tutorial (in settings) at any time
-skipTutorials=false
-
 ; This value represents how much the fall damage should be scaled in +/- %
 ; The value 50 would result in 50% higher fall damage.
 ; The value -50 would result in halved fall damage.
@@ -533,6 +530,9 @@ fallDamageScalePercent=0
 
 ; Max fall damage. Game default is 100 (so with enough health, falls can't kill).
 maxFallDamage=100
+
+; If set to true, all tutorial will skip from now on. You can turn it off and reset tutorial (in settings) at any time
+skipTutorials=false
 
 [Server]
 

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -523,10 +523,9 @@ iHaveArrivedOnSpawn=true
 ; If set to true, items will be re-equipped when you exit water after swimming (if they were hidden automatically)
 reequipItemsAfterSwimming=false
 
-<<<<<<< HEAD
 ; If set to true, all tutorial will skip from now on. You can turn it off and reset tutorial (in settings) at any time
 skipTutorials=false
-=======
+
 ; This value represents how much the fall damage should be scaled in +/- %
 ; The value 50 would result in 50% higher fall damage.
 ; The value -50 would result in halved fall damage.
@@ -534,7 +533,6 @@ fallDamageScalePercent=0
 
 ; Max fall damage. Game default is 100 (so with enough health, falls can't kill).
 maxFallDamage=100
->>>>>>> development
 
 [Server]
 

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -531,7 +531,7 @@ fallDamageScalePercent=0
 ; Max fall damage. Game default is 100 (so with enough health, falls can't kill).
 maxFallDamage=100
 
-; If set to true, all tutorial will skip from now on. You can turn it off and reset tutorial (in settings) at any time
+; If set to true, all tutorials will skip from now on. You can turn this config off and reset the tutorial (in the settings) at any time.
 skipTutorials=false
 
 [Server]

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -523,6 +523,9 @@ iHaveArrivedOnSpawn=true
 ; If set to true, items will be re-equipped when you exit water after swimming (if they were hidden automatically)
 reequipItemsAfterSwimming=false
 
+; If set to true, all tutorial will skip from now on. You can turn it off and reset tutorial (in settings) at any time
+skipTutorials=false
+
 [Server]
 
 ; Change false to true to enable this section

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -1103,6 +1103,11 @@
 				"description": "The max damage you can take from falling. Game default is 100. Applied after calculating the scaled damage.",
 				"defaultValue": "100",
 				"defaultType": "float"
+			},
+			"skipTutorials": {
+				"description": "Prevents Valkyrie from showing up to give tutorial messages. You can disable and reset tutorials in the settings if you want to see them all again.",
+				"defaultValue": "false",
+				"defaultType": "bool"
 			}
 		}
 	},


### PR DESCRIPTION
Added option to skip tutorials. Valkyrie will no longer bother you. You can always disable the option and reset the tutorial from the settings, although who would ever do that.