### PR TITLE
Update FermenterConfiguration.cs

### DIFF
--- a/ValheimPlus/Configurations/Sections/FermenterConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FermenterConfiguration.cs
@@ -2,12 +2,12 @@
 {
     public class FermenterConfiguration : ServerSyncConfig<FermenterConfiguration>
     {
-        public float fermenterDuration { get; internal set; } = 10;
+        public float fermenterDuration { get; internal set; } = 2400;
         public int fermenterItemsProduced { get; internal set; } = 4;
         public bool showDuration { get; internal set; } = false;
-        public bool autoDeposit { get; internal set; } = true;
-        public bool autoFuel { get; internal set; } = true;
-        public bool ignorePrivateAreaCheck { get; internal set; } = true;
+        public bool autoDeposit { get; internal set; } = false;
+        public bool autoFuel { get; internal set; } = false;
+        public bool ignorePrivateAreaCheck { get; internal set; } = false;
         public float autoRange { get; internal set; } = 10;
     }
 


### PR DESCRIPTION
The default fermenterDuration was set to 10, changed this back to default. Also changed autoDeposit and the likes to false, since these are settings not even available in the vanilla experience I suggest that the default value for V+ should be false, to avoid confusion for new users and so that they have to opt-in, instead of the opposite.