### PR TITLE
Added In-game clock

### DIFF
--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -46,5 +46,6 @@ namespace ValheimPlus.Configurations
         public ValheimPlusConfiguration ValheimPlus { get; set; }
         public PlayerProjectileConfiguration PlayerProjectile { get; set; }
         public MonsterProjectileConfiguration MonsterProjectile { get; set; }
+        public GameClockCongifuration GameClock { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -46,6 +46,6 @@ namespace ValheimPlus.Configurations
         public ValheimPlusConfiguration ValheimPlus { get; set; }
         public PlayerProjectileConfiguration PlayerProjectile { get; set; }
         public MonsterProjectileConfiguration MonsterProjectile { get; set; }
-        public GameClockCongifuration GameClock { get; set; }
+        public GameClockConfiguration GameClock { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/Sections/GameClockConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/GameClockConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿namespace ValheimPlus.Configurations.Sections
 {
-    public class GameClockCongifuration : ServerSyncConfig<GameClockCongifuration>
+    public class GameClockConfiguration : ServerSyncConfig<GameClockConfiguration>
     {
         public bool useAMPM { get; set; } = false;
 

--- a/ValheimPlus/Configurations/Sections/GameClockCongifuration.cs
+++ b/ValheimPlus/Configurations/Sections/GameClockCongifuration.cs
@@ -1,0 +1,14 @@
+﻿namespace ValheimPlus.Configurations.Sections
+{
+    public class GameClockCongifuration : ServerSyncConfig<GameClockCongifuration>
+    {
+        public bool useAMPM { get; set; } = false;
+
+        public int textFontSize { get; set; } = 34;
+
+        public float textRedChannelRatio { get; set; } = 0.9725f;
+        public float textGreenChannelRatio { get; set; } = 0.4118f;
+        public float textBlueChannelRatio { get; set; } = 0;
+        public float textTransparencyChannelRatio { get; set; } = 1f;
+    }
+}

--- a/ValheimPlus/Configurations/Sections/GameClockCongifuration.cs
+++ b/ValheimPlus/Configurations/Sections/GameClockCongifuration.cs
@@ -6,9 +6,9 @@
 
         public int textFontSize { get; set; } = 34;
 
-        public float textRedChannelRatio { get; set; } = 0.9725f;
-        public float textGreenChannelRatio { get; set; } = 0.4118f;
-        public float textBlueChannelRatio { get; set; } = 0;
-        public float textTransparencyChannelRatio { get; set; } = 1f;
+        public int textRedChannel { get; set; } = 248;
+        public int textGreenChannel { get; set; } = 105;
+        public int textBlueChannel { get; set; } = 0;
+        public int textTransparencyChannel { get; set; } = 255;
     }
 }

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -77,6 +77,67 @@ namespace ValheimPlus.GameClasses
                 ApplyDodgeHotkeys(ref __instance, ref ___m_moveDir, ref ___m_lookDir);
             }
 
+            /// <summary>
+            /// Display game clock
+            /// </summary>
+            if (Configuration.Current.GameClock.IsEnabled)
+            {
+                EnvMan env = EnvMan.instance;
+                float minuteFrac = Mathf.Lerp(0, 24, env.GetDayFraction());
+                float hr24 = Mathf.Floor(minuteFrac);
+                minuteFrac = minuteFrac - hr24;
+                float minutes = Mathf.Lerp(0, 60, minuteFrac);
+
+                int hours_int = Mathf.FloorToInt(hr24);
+                int minutes_int = Mathf.FloorToInt(minutes);
+
+                String hours_str = "";
+                String minutes_str = "";
+                String amPM_str = "";
+
+                if (Configuration.Current.GameClock.useAMPM)
+                {
+                    amPM_str = (hours_int < 12) ? " AM" : " PM";
+                    if (hours_int > 12) hours_int -= 12;
+                }
+
+                if (hours_int < 10) hours_str = "0" + hours_int;
+                if (minutes_int < 10) minutes_str = "0" + minutes_int;
+                if (hours_int >= 10) hours_str = hours_int.ToString();
+                if (minutes_int >= 10) minutes_str = minutes_int.ToString();
+
+                Hud hud = Hud.instance;
+
+                Text timeText;
+                if (timeObj == null)
+                {
+                    MessageHud msgHud = MessageHud.instance;
+
+                    timeObj = new GameObject();
+                    timeObj.transform.SetParent(hud.m_statusEffectListRoot.transform.parent);
+                    timeObj.AddComponent<RectTransform>();
+
+                    timeText = timeObj.AddComponent<Text>();
+
+                    float rRatio = Mathf.Clamp01(Configuration.Current.GameClock.textRedChannelRatio);
+                    float gRatio = Mathf.Clamp01(Configuration.Current.GameClock.textGreenChannelRatio);
+                    float bRatio = Mathf.Clamp01(Configuration.Current.GameClock.textBlueChannelRatio);
+                    float aRatio = Mathf.Clamp01(Configuration.Current.GameClock.textTransparencyChannelRatio);
+
+                    timeText.color = new Color(rRatio, gRatio, bRatio, aRatio);
+                    timeText.font = msgHud.m_messageCenterText.font;
+                    timeText.fontSize = Configuration.Current.GameClock.textFontSize;
+                    timeText.enabled = true;
+                    timeText.alignment = TextAnchor.MiddleCenter;
+                    timeText.horizontalOverflow = HorizontalWrapMode.Overflow;
+                }
+                else timeText = timeObj.GetComponent<Text>();
+                timeText.text = hours_str + ":" + minutes_str + amPM_str;
+                var staminaBarRec = hud.m_staminaBar2Root.transform as RectTransform;
+                var statusEffictBarRec = hud.m_statusEffectListRoot.transform as RectTransform;
+                timeObj.GetComponent<RectTransform>().position = new Vector2(staminaBarRec.position.x, statusEffictBarRec.position.y);
+                timeObj.SetActive(true);
+            }
         }
 
         private static void ApplyDodgeHotkeys(ref Player __instance, ref Vector3 ___m_moveDir, ref Vector3 ___m_lookDir)

--- a/ValheimPlus/GameClasses/Player.cs
+++ b/ValheimPlus/GameClasses/Player.cs
@@ -119,10 +119,10 @@ namespace ValheimPlus.GameClasses
 
                     timeText = timeObj.AddComponent<Text>();
 
-                    float rRatio = Mathf.Clamp01(Configuration.Current.GameClock.textRedChannelRatio);
-                    float gRatio = Mathf.Clamp01(Configuration.Current.GameClock.textGreenChannelRatio);
-                    float bRatio = Mathf.Clamp01(Configuration.Current.GameClock.textBlueChannelRatio);
-                    float aRatio = Mathf.Clamp01(Configuration.Current.GameClock.textTransparencyChannelRatio);
+                    float rRatio = Mathf.Clamp01((float)Configuration.Current.GameClock.textRedChannel / 255f);
+                    float gRatio = Mathf.Clamp01((float)Configuration.Current.GameClock.textGreenChannel / 255f);
+                    float bRatio = Mathf.Clamp01((float)Configuration.Current.GameClock.textBlueChannel / 255f);
+                    float aRatio = Mathf.Clamp01((float)Configuration.Current.GameClock.textTransparencyChannel / 255f);
 
                     timeText.color = new Color(rRatio, gRatio, bRatio, aRatio);
                     timeText.font = msgHud.m_messageCenterText.font;

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -330,6 +330,7 @@
   <ItemGroup>
     <Compile Include="AdvancedBuildingMode.cs" />
     <Compile Include="AdvancedEditingMode.cs" />
+    <Compile Include="Configurations\Sections\GameClockCongifuration.cs" />
     <Compile Include="Configurations\Sections\MonsterProjectileConfiguration.cs" />
     <Compile Include="Configurations\Sections\PlayerProjectileConfiguration.cs" />
     <Compile Include="Configurations\Sections\CraftFromChestConfiguration.cs" />

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -330,7 +330,7 @@
   <ItemGroup>
     <Compile Include="AdvancedBuildingMode.cs" />
     <Compile Include="AdvancedEditingMode.cs" />
-    <Compile Include="Configurations\Sections\GameClockCongifuration.cs" />
+    <Compile Include="Configurations\Sections\GameClockConfiguration.cs" />
     <Compile Include="Configurations\Sections\MonsterProjectileConfiguration.cs" />
     <Compile Include="Configurations\Sections\PlayerProjectileConfiguration.cs" />
     <Compile Include="Configurations\Sections\CraftFromChestConfiguration.cs" />

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -882,14 +882,14 @@ useAMPM=false
 ; Change font size of time text. 
 textFontSize=34
 
-; Change how red the time text is (51/255 = 0.2).
-textRedChannelRatio=0.9725
+; Change how red the time text is (51/255).
+textRedChannelRatio=248
 
-; Change how green the time text is (51/255 = 0.2).
-textGreenChannelRatio=0.4118
+; Change how green the time text is (51/255).
+textGreenChannelRatio=105
 
-; Change how blue the time text is (51/255 = 0.2).
+; Change how blue the time text is (51/255).
 textBlueChannelRatio=0
 
-; Change how transparent the time text is (1 is solid with no transparency).
-textTransparencyChannelRatio=1
+; Change how transparent the time text is (255 is solid with no transparency).
+textTransparencyChannelRatio=255

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -869,3 +869,27 @@ monsterMaxChargeVelocityMultiplier=0
 
 ; Value of (+)10 increase in accruracy will change the variance of projectile 1 degree to 0.9 degree at the point of projectile release.
 monsterMaxChargeAccuracyMultiplier=0
+
+
+[GameClock]
+
+; Change false to true to enable this section. https://valheim.plus/documentation/list#GameClock
+enabled=false
+
+; Change time formatting from 24hr to AM-PM.
+useAMPM=false
+
+; Change font size of time text. 
+textFontSize=34
+
+; Change how red the time text is (51/255 = 0.2).
+textRedChannelRatio=0.9725
+
+; Change how green the time text is (51/255 = 0.2).
+textGreenChannelRatio=0.4118
+
+; Change how blue the time text is (51/255 = 0.2).
+textBlueChannelRatio=0
+
+; Change how transparent the time text is (1 is solid with no transparency).
+textTransparencyChannelRatio=1

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -1794,23 +1794,23 @@
 			},
 			"textRedChannelRatio": {
 				"description": "Change how red the time text is.",
-				"defaultValue": "0.9725",
-				"defaultType": "float"
+				"defaultValue": "248",
+				"defaultType": "int"
 			},
 			"textGreenChannelRatio": {
 				"description": "Change how green the time text is.",
-				"defaultValue": "0.4118",
-				"defaultType": "float"
+				"defaultValue": "105",
+				"defaultType": "int"
 			},
 			"textBlueChannelRatio": {
 				"description": "Change how blue the time text is.",
 				"defaultValue": "0",
-				"defaultType": "float"
+				"defaultType": "int"
 			},
 			"textTransparencyChannelRatio": {
 				"description": "Change how transparent the time text is.",
-				"defaultValue": "1",
-				"defaultType": "float"
+				"defaultValue": "255",
+				"defaultType": "int"
 			}
 		}
 	}

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -1771,5 +1771,47 @@
 				"modifier": "true"
 			}
 		}
+	},
+	"GameClock": {
+		"description": "",
+		"icon": "far fa-clock",
+		"description_website": "Shows In-Game digital clock in top center. Days starts at 0600 and sun sets at 1800.",
+		"entries": {
+			"enabled": {
+				"description": "Change false to true to enable this section",
+				"defaultType": "bool",
+				"defaultValue": "false"
+			},
+			"useAMPM": {
+				"description": "Change time format from 24hr to AM-PM",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
+			"textFontSize": {
+				"description": "Change font size of time text",
+				"defaultValue": "34",
+				"defaultType": "int"
+			},
+			"textRedChannelRatio": {
+				"description": "Change how red the time text is.",
+				"defaultValue": "0.9725",
+				"defaultType": "float"
+			},
+			"textGreenChannelRatio": {
+				"description": "Change how green the time text is.",
+				"defaultValue": "0.4118",
+				"defaultType": "float"
+			},
+			"textBlueChannelRatio": {
+				"description": "Change how blue the time text is.",
+				"defaultValue": "0",
+				"defaultType": "float"
+			},
+			"textTransparencyChannelRatio": {
+				"description": "Change how transparent the time text is.",
+				"defaultValue": "1",
+				"defaultType": "float"
+			}
+		}
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9020992/112842699-d7218580-906f-11eb-85bf-cd87aa9d3d17.png)
#365 There was a request for In-Game clock by a lot of people (number 1 on the HUD according to the https://valheim.plus/todo).

Well here it is. 

- Allow both 24hr (default) time and AM-PM format.
- Allow user to change Font Size
- Allow user to customize r,g,b,a channels