### PR TITLE
Allow all ores in blast furnace

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ We work together closely to make sure all our features are integrated and workin
 * Allow fuel-type items to be automatically pulled from closest containers.
 * Allow Kiln to stop pulling wood from closest containers when a specific threshold as been reached. 
 * Allow items produced by Kiln, Furnace and Blast Furnace to be automatically placed in the closest containers.
+* Allow Furnace to process all ore types instead of just Black Metal Scrap and Flametal Ore.
 
 ### Beehive 
 * Modify Beehive honey production speed.

--- a/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FurnaceConfiguration.cs
@@ -10,6 +10,7 @@
         public bool autoFuel { get; internal set; } = false;
         public bool ignorePrivateAreaCheck { get; internal set; } = true;
         public float autoRange { get; internal set; } = 10;
+        public bool allowAllOres { get; internal set; } = false;
     }
 
 }

--- a/ValheimPlus/GameClasses/Smelter.cs
+++ b/ValheimPlus/GameClasses/Smelter.cs
@@ -35,6 +35,11 @@ namespace ValheimPlus.GameClasses
                 __instance.m_maxFuel = Configuration.Current.Furnace.maximumCoal;
                 __instance.m_secPerProduct = Configuration.Current.Furnace.productionSpeed;
                 __instance.m_fuelPerProduct = Configuration.Current.Furnace.coalUsedPerProduct;
+
+                if (Configuration.Current.Furnace.allowAllOres)
+                {
+                    __instance.m_conversion.AddRange(FurnaceDefinitions.AdditionalConversions);
+                }
             }
             else if (__instance.m_name.Equals(SmelterDefinitions.WindmillName) && Configuration.Current.Windmill.IsEnabled)
             {
@@ -340,6 +345,27 @@ namespace ValheimPlus.GameClasses
         public static readonly string FurnaceName = "$piece_blastfurnace";
         public static readonly string WindmillName = "$piece_windmill";
         public static readonly string SpinningWheelName = "$piece_spinningwheel";
+    }
+
+    public static class FurnaceDefinitions
+    {
+        public static readonly string CopperOrePrefabName = "CopperOre";
+        public static readonly string IronOrePrefabName = "IronOre";
+        public static readonly string SilverOrePrefabName = "SilverOre";
+        public static readonly string TinOrePrefabName = "TinOre";
+
+        public static readonly string CopperPrefabName = "Copper";
+        public static readonly string IronPrefabName = "Iron";
+        public static readonly string SilverPrefabName = "Silver";
+        public static readonly string TinPrefabName = "Tin";
+
+        public static readonly List<Smelter.ItemConversion> AdditionalConversions = new List<Smelter.ItemConversion>
+        {
+            new Smelter.ItemConversion() { m_from = ObjectDB.instance.GetItemPrefab(CopperOrePrefabName).GetComponent<ItemDrop>(), m_to = ObjectDB.instance.GetItemPrefab(CopperPrefabName).GetComponent<ItemDrop>().GetComponent<ItemDrop>() },
+            new Smelter.ItemConversion() { m_from = ObjectDB.instance.GetItemPrefab(IronOrePrefabName).GetComponent<ItemDrop>(), m_to = ObjectDB.instance.GetItemPrefab(IronPrefabName).GetComponent<ItemDrop>().GetComponent<ItemDrop>() },
+            new Smelter.ItemConversion() { m_from = ObjectDB.instance.GetItemPrefab(SilverOrePrefabName).GetComponent<ItemDrop>(), m_to = ObjectDB.instance.GetItemPrefab(SilverPrefabName).GetComponent<ItemDrop>().GetComponent<ItemDrop>() },
+            new Smelter.ItemConversion() { m_from = ObjectDB.instance.GetItemPrefab(TinOrePrefabName).GetComponent<ItemDrop>(), m_to = ObjectDB.instance.GetItemPrefab(TinPrefabName).GetComponent<ItemDrop>().GetComponent<ItemDrop>() }
+        };
     }
 
     public static class WoodDefinitions

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -301,6 +301,10 @@ ignorePrivateAreaCheck=true
 ; The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)
 autoRange=10
 
+; Change to true or false to enable the use of all ores.
+; default: false
+allowAllOres=false
+
 [Game]
 
 ; Change false to true to enable this section. https://valheim.plus/documentation/list#Game

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -585,6 +585,11 @@
 				"description": "The range of the chest detection for the auto deposit and fuel features. (Maximum is 50)",
 				"defaultValue": "10",
 				"defaultType": "float"
+			},
+			"allowAllOres": {
+				"description": "Change to true or false to enable the use of all ores.",
+				"defaultValue": "false",
+				"defaultType": "bool"
 			}
 		}
 	},


### PR DESCRIPTION
Added Furnace feature so users can choose whether the Blast Furnace is able to process all ores instead of just Black Metal and Flametal(was a community suggestion on https://valheim.plus/todo).