### PR TITLE
Alpha feedback fixes

### DIFF
--- a/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
@@ -4,13 +4,13 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class AdvancedBuildingModeConfiguration : BaseConfig<AdvancedBuildingModeConfiguration>
     {
-        public KeyCode enterAdvancedBuildingMode { get; set; } = KeyCode.F1;
-        public KeyCode exitAdvancedBuildingMode { get; set; } = KeyCode.F3;
+        public KeyCode enterAdvancedBuildingMode { get; internal set; } = KeyCode.F1;
+        public KeyCode exitAdvancedBuildingMode { get; internal set; } = KeyCode.F3;
 
-        public KeyCode copyObjectRotation { get; set; } = KeyCode.Keypad7;
-        public KeyCode pasteObjectRotation { get; set; } = KeyCode.Keypad8;
+        public KeyCode copyObjectRotation { get; internal set; } = KeyCode.Keypad7;
+        public KeyCode pasteObjectRotation { get; internal set; } = KeyCode.Keypad8;
 
-        public KeyCode increaseScrollSpeed { get; set; } = KeyCode.KeypadPlus;
-        public KeyCode decreaseScrollSpeed { get; set; } = KeyCode.KeypadMinus;
+        public KeyCode increaseScrollSpeed { get; internal set; } = KeyCode.KeypadPlus;
+        public KeyCode decreaseScrollSpeed { get; internal set; } = KeyCode.KeypadMinus;
     }
 }

--- a/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
@@ -12,10 +12,10 @@ namespace ValheimPlus.Configurations.Sections
         public KeyCode resetAdvancedEditingMode { get; internal set; } = KeyCode.F7;
         public KeyCode abortAndExitAdvancedEditingMode { get; internal set; } =  KeyCode.F8;
         public KeyCode confirmPlacementOfAdvancedEditingMode { get; internal set; } = KeyCode.KeypadEnter;
-        public KeyCode copyObjectRotation { get; set; } = KeyCode.Keypad7;
-        public KeyCode pasteObjectRotation { get; set; } = KeyCode.Keypad8;
+        public KeyCode copyObjectRotation { get; internal set; } = KeyCode.Keypad7;
+        public KeyCode pasteObjectRotation { get; internal set; } = KeyCode.Keypad8;
 
-        public KeyCode increaseScrollSpeed { get; set; } = KeyCode.KeypadPlus;
-        public KeyCode decreaseScrollSpeed { get; set; } = KeyCode.KeypadMinus;
+        public KeyCode increaseScrollSpeed { get; internal set; } = KeyCode.KeypadPlus;
+        public KeyCode decreaseScrollSpeed { get; internal set; } = KeyCode.KeypadMinus;
     }
 }

--- a/ValheimPlus/Configurations/Sections/BeehiveConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BeehiveConfiguration.cs
@@ -2,11 +2,11 @@
 {
     public class BeehiveConfiguration : ServerSyncConfig<BeehiveConfiguration>
     {
-        public float honeyProductionSpeed { get; set; } = 1200;
-        public int maximumHoneyPerBeehive { get; set; } = 4;
-        public bool autoDeposit { get; set; } = false;
-        public float autoDepositRange { get; set; } = 10;
-        public bool showDuration { get; set; } = false;
+        public float honeyProductionSpeed { get; internal set; } = 1200;
+        public int maximumHoneyPerBeehive { get; internal set; } = 4;
+        public bool autoDeposit { get; internal set; } = false;
+        public float autoDepositRange { get; internal set; } = 10;
+        public bool showDuration { get; internal set; } = false;
     }
 
 }

--- a/ValheimPlus/Configurations/Sections/BuildingConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BuildingConfiguration.cs
@@ -2,9 +2,9 @@
 {
     public class BuildingConfiguration : ServerSyncConfig<BuildingConfiguration>
     {
-        public bool noInvalidPlacementRestriction { get; set; } = false;
-        public bool noMysticalForcesPreventPlacementRestriction { get; set; } = false;
-        public bool noWeatherDamage { get; set; } = false;
+        public bool noInvalidPlacementRestriction { get; internal set; } = false;
+        public bool noMysticalForcesPreventPlacementRestriction { get; internal set; } = false;
+        public bool noWeatherDamage { get; internal set; } = false;
         public float maximumPlacementDistance { get; internal set; } = 5;
         public float pieceComfortRadius { get; internal set; } = 10;
         public bool alwaysDropResources { get; internal set; } = false;

--- a/ValheimPlus/Configurations/Sections/FoodConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/FoodConfiguration.cs
@@ -2,8 +2,7 @@
 {
     public class FoodConfiguration : ServerSyncConfig<FoodConfiguration>
     {
-        public float foodDurationMultiplier { get; set; } = 0;
-        public bool disableFoodDegradation { get; set; } = false;
+        public float foodDurationMultiplier { get; internal set; } = 0;
+        public bool disableFoodDegradation { get; internal set; } = false;
     }
-
 }

--- a/ValheimPlus/Configurations/Sections/GameConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/GameConfiguration.cs
@@ -7,8 +7,8 @@
         public int extraPlayerCountNearby { get; internal set; } = 0;
         public int setFixedPlayerCountTo { get; internal set; } = 0;
         public int difficultyScaleRange { get; internal set; } = 200;
-        public bool disablePortals { get; set; } = false;
-        public bool forceConsole { get; set; } = false;
-        public bool bigPortalNames { get; set; } = false;
+        public bool disablePortals { get; internal set; } = false;
+        public bool forceConsole { get; internal set; } = false;
+        public bool bigPortalNames { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/Configurations/Sections/GridAlignmentConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/GridAlignmentConfiguration.cs
@@ -4,8 +4,8 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class GridAlignmentConfiguration : ServerSyncConfig<GridAlignmentConfiguration>
     {
-        public KeyCode align { get; set; } = KeyCode.LeftAlt;
-        public KeyCode alignToggle { get; set; } = KeyCode.F7;
-        public KeyCode changeDefaultAlignment { get; set; } = KeyCode.F6;
+        public KeyCode align { get; internal set; } = KeyCode.LeftAlt;
+        public KeyCode alignToggle { get; internal set; } = KeyCode.F7;
+        public KeyCode changeDefaultAlignment { get; internal set; } = KeyCode.F6;
     }
 }

--- a/ValheimPlus/Configurations/Sections/HotkeyConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/HotkeyConfiguration.cs
@@ -4,7 +4,7 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class HotkeyConfiguration : BaseConfig<HotkeyConfiguration>
     {
-        public KeyCode rollForwards { get; set; } = KeyCode.F9;
-        public KeyCode rollBackwards { get; set; } = KeyCode.F10;
+        public KeyCode rollForwards { get; internal set; } = KeyCode.F9;
+        public KeyCode rollBackwards { get; internal set; } = KeyCode.F10;
     }
 }

--- a/ValheimPlus/Configurations/Sections/InventoryConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/InventoryConfiguration.cs
@@ -2,20 +2,20 @@ namespace ValheimPlus.Configurations.Sections
 {
     public class InventoryConfiguration : ServerSyncConfig<InventoryConfiguration>
     {
-        public bool inventoryFillTopToBottom { get; set; } = false;
-        public bool mergeWithExistingStacks { get; set; } = false;
-        public int playerInventoryRows { get; set; } = 4;
-        public int woodChestColumns { get; set; } = 5;
-        public int woodChestRows { get; set; } = 2;
-        public int personalChestColumns { get; set; } = 3;
-        public int personalChestRows { get; set; } = 2;
-        public int ironChestColumns { get; set; } = 8;
-        public int ironChestRows { get; set; } = 4;
-        public int cartInventoryColumns { get; set; } = 8;
-        public int cartInventoryRows { get; set; } = 3;
-        public int karveInventoryColumns { get; set; } = 2;
-        public int karveInventoryRows { get; set; } = 2;
-        public int longboatInventoryColumns { get; set; } = 8;
-        public int longboatInventoryRows { get; set; } = 3;
+        public bool inventoryFillTopToBottom { get; internal set; } = false;
+        public bool mergeWithExistingStacks { get; internal set; } = false;
+        public int playerInventoryRows { get; internal set; } = 4;
+        public int woodChestColumns { get; internal set; } = 5;
+        public int woodChestRows { get; internal set; } = 2;
+        public int personalChestColumns { get; internal set; } = 3;
+        public int personalChestRows { get; internal set; } = 2;
+        public int ironChestColumns { get; internal set; } = 8;
+        public int ironChestRows { get; internal set; } = 4;
+        public int cartInventoryColumns { get; internal set; } = 8;
+        public int cartInventoryRows { get; internal set; } = 3;
+        public int karveInventoryColumns { get; internal set; } = 2;
+        public int karveInventoryRows { get; internal set; } = 2;
+        public int longboatInventoryColumns { get; internal set; } = 8;
+        public int longboatInventoryRows { get; internal set; } = 3;
     }
 }

--- a/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/KilnConfiguration.cs
@@ -2,7 +2,7 @@
 {
     public class KilnConfiguration : ServerSyncConfig<KilnConfiguration>
     {
-        public float productionSpeed { get; internal set; } = 16;
+        public float productionSpeed { get; internal set; } = 15;
         public int maximumWood { get; internal set; } = 25;
         public bool dontProcessFineWood { get; internal set; } = false;
         public bool dontProcessRoundLog { get; internal set; } = false;

--- a/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ServerConfiguration.cs
@@ -2,8 +2,8 @@
 {
     public class ServerConfiguration : BaseConfig<ServerConfiguration>
     {
-        public int maxPlayers { get; set; } = 10;
-        public bool disableServerPassword { get; set; } = false;
+        public int maxPlayers { get; internal set; } = 10;
+        public bool disableServerPassword { get; internal set; } = false;
         public bool enforceMod { get; internal set; } = true;
         public bool serverSyncsConfig { get; internal set; } = true;
         public bool serverSyncHotkeys { get; internal set; } = true;

--- a/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/StructuralIntegrityConfiguration.cs
@@ -6,9 +6,9 @@
         public float stone { get; internal set; } = 0;
         public float iron { get; internal set; } = 0;
         public float hardWood { get; internal set; } = 0;
-        public bool disableStructuralIntegrity { get; set; } = false;
-        public bool disableDamageToPlayerStructures { get; set; } = false;
-        public bool disableDamageToPlayerBoats { get; set; } = false;
-        public bool disableWaterDamageToPlayerBoats { get; set; } = false;
+        public bool disableStructuralIntegrity { get; internal set; } = false;
+        public bool disableDamageToPlayerStructures { get; internal set; } = false;
+        public bool disableDamageToPlayerBoats { get; internal set; } = false;
+        public bool disableWaterDamageToPlayerBoats { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/Attack.cs
+++ b/ValheimPlus/GameClasses/Attack.cs
@@ -118,4 +118,3 @@ namespace ValheimPlus.GameClasses
         }
     }
 }
-}

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -287,6 +287,8 @@ namespace ValheimPlus.GameClasses
     {
         private static bool Prefix(Transform elementRoot, Piece.Requirement req, Player player, bool craft, int quality, ref bool __result)
         {
+            if (!Configuration.Current.Hud.IsEnabled || !Configuration.Current.Hud.showRequiredItems) return true;
+
             Image component = elementRoot.transform.Find("res_icon").GetComponent<Image>();
             Text component2 = elementRoot.transform.Find("res_name").GetComponent<Text>();
             Text component3 = elementRoot.transform.Find("res_amount").GetComponent<Text>();

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -25,7 +25,7 @@ namespace ValheimPlus
                 {
                     Container foundContainer = hitCollider.GetComponentInParent<Container>();
                     bool hasAccess = foundContainer.CheckAccess(Player.m_localPlayer.GetPlayerID());
-                    if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(target.transform.position, 0f, false, true);
+                    if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(hitCollider.gameObject.transform.position, 0f, false, true);
                     if (foundContainer.m_name.Contains("piece_chest") && hasAccess && foundContainer.GetInventory() != null)
                     {
                         validContainers.Add(foundContainer);

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -440,7 +440,7 @@ dontProcessFineWood=false
 dontProcessRoundLog=false
 
 ; The time it takes for the Kiln to produce a single piece of coal in seconds.
-productionSpeed=16
+productionSpeed=15
 
 ; Instead of dropping the items, they will be placed inside nearby chests.
 autoDeposit=false

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -941,7 +941,7 @@
 			},
 			"productionSpeed": {
 				"description": "The time it takes for the Kiln to produce a single piece of coal in seconds.",
-				"defaultValue": "16",
+				"defaultValue": "15",
 				"defaultType": "float"
 			},
 			"autoDeposit": {


### PR DESCRIPTION
Some more fixes related to alpha 0.9.7B

- Fix `PrivateArea.CheckAccess` calls
- Use internal setters for configurations
- Change charcoal default production speed to 15 (game default value)
- Remove unwanted curly bracket introduced by 4080e2e
