### PR TITLE
Allow modifiying Pickable yield

### DIFF
--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -37,6 +37,7 @@ namespace ValheimPlus.Configurations
         public GameConfiguration Game { get; set; }
         public WagonConfiguration Wagon { get; set; }
         public GatherConfiguration Gathering { get; set; }
+        public PickableConfiguration Pickable { get; set; }
         public DurabilityConfiguration Durability { get; set; }
         public ArmorConfiguration Armor { get; set; }
 	    public FreePlacementRotationConfiguration FreePlacementRotation { get; set; }

--- a/ValheimPlus/Configurations/Sections/PickableConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/PickableConfiguration.cs
@@ -1,0 +1,11 @@
+﻿namespace ValheimPlus.Configurations.Sections
+{
+    public class PickableConfiguration : ServerSyncConfig<PickableConfiguration>
+    {
+        public float edibles { get; internal set; } = 0;
+        public float flowersAndIngredients { get; internal set; } = 0;
+        public float materials { get; internal set; } = 0;
+        public float valuables { get; internal set; } = 0;
+        public float surtlingCores { get; internal set; } = 0;
+    }
+}

--- a/ValheimPlus/GameClasses/Pickable.cs
+++ b/ValheimPlus/GameClasses/Pickable.cs
@@ -1,0 +1,154 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+using ValheimPlus;
+using ValheimPlus.Configurations;
+using ValheimPlus.Utility;
+
+namespace ValheimPlus.GameClasses
+{
+    public static class PickableYieldState
+    {
+        public static Dictionary<string, float> yieldModifier;
+    }
+
+    /// <summary>
+    /// Allow tweaking of Pickable item yield. (E.g. berries, flowers, branches, stones, gemstones.)
+    /// </summary>
+    [HarmonyPatch(typeof(Pickable), "RPC_Pick")]
+    public static class Pickable_RPC_Pick_Transpiler
+    {
+        // Our method and its arguments that we need to patch in
+        private static readonly MethodInfo method_calculateYield = AccessTools.Method(typeof(Pickable_RPC_Pick_Transpiler), nameof(calculateYield));
+        private static readonly FieldInfo field_ItemPrefab = AccessTools.Field(typeof(Pickable), "m_itemPrefab");
+        private static readonly FieldInfo field_amount = AccessTools.Field(typeof(Pickable), "m_amount");
+
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            if (!Configuration.Current.Pickable.IsEnabled)
+                return instructions;
+
+            List<CodeInstruction> il = instructions.ToList();
+
+            LocalBuilder newYieldLocal = null;
+            for (int i = 0; i < il.Count; i++)
+            {
+                if (newYieldLocal == null && i > 0 && il[i].opcode == OpCodes.Stloc_1 && il[i - 1].opcode == OpCodes.Ldc_I4_0)
+                {
+                    // Step 1: Call calculateYield() and store the result as a new local variable.
+                    //
+                    // Calling calculateYield takes several instructions:
+                    // LdArg.0 (load the "this" pointer), LdFld (load m_itemPrefab from this), LdArg.0 (this), LdFld (load m_amount from this), Call.
+                    // We then store the return value as our new local, used in the second patch below.
+                    newYieldLocal = generator.DeclareLocal(typeof(int));
+                    newYieldLocal.SetLocalSymInfo("newYieldLocal");
+                    il.Insert(++i, new CodeInstruction(OpCodes.Ldarg_0));
+                    il.Insert(++i, new CodeInstruction(OpCodes.Ldfld, field_ItemPrefab));
+                    il.Insert(++i, new CodeInstruction(OpCodes.Ldarg_0));
+                    il.Insert(++i, new CodeInstruction(OpCodes.Ldfld, field_amount));
+                    il.Insert(++i, new CodeInstruction(new CodeInstruction(OpCodes.Call, method_calculateYield)));
+                    il.Insert(++i, new CodeInstruction(OpCodes.Stloc_S, newYieldLocal.LocalIndex));
+                }
+
+                if (newYieldLocal != null && il[i].opcode == OpCodes.Ldfld && il[i].operand.ToString().Contains("m_amount"))
+                {
+                    // Step 2: Patch the for loop to loop calculateYield() iterations instead of m_amount iterations,
+                    // by replacing m_amount with our new local variable, created above.
+                    //
+                    // Get rid of LdArg.1 (i-1) and LdFld (i) and replace them with loading our previously calculated yield.
+                    il[i] = new CodeInstruction(OpCodes.Ldloc_S, newYieldLocal.LocalIndex);
+                    il.RemoveRange(i - 1, 1);
+
+                    ZLog.Log("Successfully transpiled Pickable.RPC_Pick to patch item yields");
+
+                    // NOTE: This transpiler may be called multiple times, e.g. when starting the game, when connecting to a server and when disconnecting.
+                    // We need to re-do the initial setup every time, since the modifier values may have changed (as the server config will be used instead of the client config).
+                    initialSetup();
+
+                    return il.AsEnumerable();
+                }
+            }
+
+            ZLog.Log("Unable to transpile Pickable.RPC_Pick to patch item yields");
+            return instructions;
+        }
+
+        private static int calculateYield(GameObject item, int originalAmount)
+        {
+            try
+            {
+                return (int)Helper.applyModifierValue(originalAmount, PickableYieldState.yieldModifier[item.name]);
+            }
+            catch
+            {
+                return originalAmount;
+            }
+        }
+
+        private static void initialSetup()
+        {
+            // Called from the transpiler, so this will be run when the game starts, plus when you connect to or disconnect from a server.
+
+            var edibles = new List<string>
+            {
+                "Carrot",
+                "Blueberries",
+                "Cloudberry",
+                "Raspberry",
+                "Mushroom",
+                "MushroomBlue",
+                "MushroomYellow",
+            };
+
+            var flowersAndIngredients = new List<string>
+            {
+                "Barley",
+                "CarrotSeeds",
+                "Dandelion",
+                "Flax",
+                "Thistle",
+                "TurnipSeeds",
+                "Turnip"
+            };
+
+            var materials = new List<string>
+            {
+                "BoneFragments",
+                "Flint",
+                "Stone",
+                "Wood"
+            };
+
+            var valuables = new List<string>
+            {
+                "Amber",
+                "AmberPearl",
+                "Coins",
+                "Ruby"
+            };
+
+            var surtlingCores = new List<string>
+            {
+                "SurtlingCore"
+            };
+
+            PickableYieldState.yieldModifier = new Dictionary<string, float>();
+
+            foreach (var item in edibles)
+                PickableYieldState.yieldModifier.Add(item, Configuration.Current.Pickable.edibles);
+            foreach (var item in flowersAndIngredients)
+                PickableYieldState.yieldModifier.Add(item, Configuration.Current.Pickable.flowersAndIngredients);
+            foreach (var item in materials)
+                PickableYieldState.yieldModifier.Add(item, Configuration.Current.Pickable.materials);
+            foreach (var item in valuables)
+                PickableYieldState.yieldModifier.Add(item, Configuration.Current.Pickable.valuables);
+            foreach (var item in surtlingCores)
+                PickableYieldState.yieldModifier.Add(item, Configuration.Current.Pickable.surtlingCores);
+        }
+    }
+}

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -338,6 +338,7 @@
     <Compile Include="Configurations\Sections\DeconstructConfiguration.cs" />
     <Compile Include="Configurations\Sections\ArmorConfiguration.cs" />
     <Compile Include="Configurations\Sections\DurabilityConfiguration.cs" />
+    <Compile Include="Configurations\Sections\PickableConfiguration.cs" />
     <Compile Include="Configurations\Sections\SmelterConfiguration.cs" />
     <Compile Include="Configurations\Sections\FreePlacementRotationConfiguration.cs" />
     <Compile Include="Configurations\Sections\GatherConfiguration.cs" />
@@ -390,6 +391,7 @@
     <Compile Include="GameClasses\Hud.cs" />
     <Compile Include="GameClasses\EventSystem.cs" />
     <Compile Include="GameClasses\MonsterAI.cs" />
+    <Compile Include="GameClasses\Pickable.cs" />
     <Compile Include="GameClasses\Settings.cs" />
     <Compile Include="GameClasses\SE_Rested.cs" />
     <Compile Include="GameClasses\Piece.cs" />

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -400,6 +400,26 @@ copperOre=0
 silverOre=0
 chitin=0
 
+[Pickable]
+
+; Change false to true to enable this section. Each value below (in percent) will modify the yield when "picking" items (default key E) such as berries and flowers. A value of 100 will double drops, 200 will triple. Also see: https://valheim.plus/documentation/list#Pickable
+enabled=false
+
+; All berries, all mushrooms, and carrots
+edibles=0
+
+; Barley, Flax, Dandelion, Thistle, Carrot Seeds, Turnip Seeds, Turnip
+flowersAndIngredients=0
+
+; Bone Fragments, Flint, Stone, Wood (branches on the ground)
+materials=0
+
+; Amber, Amber Pearl, Coins, Ruby
+valuables=0
+
+; Surtling Core only
+surtlingCores=0
+
 [Durability]
 
 ; Change false to true to enable this section. This section contains modifiers. Modifiers are increases and reduction in percent declared by 50, or -50. https://valheim.plus/documentation/list#Durability

--- a/vplusSuggestions/todo.json
+++ b/vplusSuggestions/todo.json
@@ -317,12 +317,6 @@
     "status": "In Consideration",
     "category": "Map"
   },
-  "Modifiers for Berries and Bushes": {
-    "description": "Add a configuration settings to modify the amount of berries harvested from bushes. <a target='_blank' href='https://github.com/valheimPlus/ValheimPlus/issues/222'>reference</a>",
-    "icon": "fab fa-raspberry-pi",
-    "status": "In Consideration",
-    "category": "Items"
-  },
   "Modify Block and Parry Levels of Weapons": {
     "description": "Add the ability to modify block and parry levels. Not being able to modify block values for weapons - especially 2h weapons- makes block worthless when setting up dmg scaling for +100%.",
     "icon": "fas fa-axe",

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -811,6 +811,48 @@
 			}
 		}
 	},
+	"Pickable": {
+		"description": "",
+		"icon": "fa fa-axe",
+		"description_website": "Change drop rates of pickable items such as berries and valuables.",
+		"entries": {
+			"enabled": {
+				"description": "Change false to true to enable this section",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
+			"edibles": {
+				"description": "The value 100 will double the amount of dropped resources, 200 will triple. Smaller values such as 50 only has an effect if more than 1 item would drop normally.",
+				"defaultValue": "0",
+				"defaultType": "float",
+				"modifier": "true"
+			},
+			"flowersAndIngredients": {
+				"description": "The value 100 will double the amount of dropped resources, 200 will triple. Smaller values such as 50 only has an effect if more than 1 item would drop normally.",
+				"defaultValue": "0",
+				"defaultType": "float",
+				"modifier": "true"
+			},
+			"materials": {
+				"description": "The value 100 will double the amount of dropped resources, 200 will triple. Smaller values such as 50 only has an effect if more than 1 item would drop normally.",
+				"defaultValue": "0",
+				"defaultType": "float",
+				"modifier": "true"
+			},
+			"valuables": {
+				"description": "The value 100 will double the amount of dropped resources, 200 will triple. Smaller values such as 50 only has an effect if more than 1 item would drop normally.",
+				"defaultValue": "0",
+				"defaultType": "float",
+				"modifier": "true"
+			},
+			"surtlingCores": {
+				"description": "The value 100 will double the amount of dropped resources, 200 will triple. Smaller values such as 50 only has an effect if more than 1 item would drop normally.",
+				"defaultValue": "0",
+				"defaultType": "float",
+				"modifier": "true"
+			}
+		}
+	},
 	"Durability": {
 		"description": "",
 		"icon": "fa fa-tasks-alt",


### PR DESCRIPTION
Pickables are items that appear when you press the Use button on something, e.g. a berry bush, a branch or a carrot.
This patch allows you to modify the yield of most pickables.

Probably needs a bit of extra alpha testing, but everything I've tested has worked both locally and on a dedicated server.