### PR TITLE
added mod for disable fog and brightness adjustment

### DIFF
--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -49,5 +49,6 @@ namespace ValheimPlus.Configurations
         public PlayerProjectileConfiguration PlayerProjectile { get; set; }
         public MonsterProjectileConfiguration MonsterProjectile { get; set; }
         public GameClockConfiguration GameClock { get; set; }
+        public BrightnessConfiguration Brightness { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/Sections/BrightnessConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BrightnessConfiguration.cs
@@ -2,9 +2,11 @@
 {
     public class BrightnessConfiguration : BaseConfig<BrightnessConfiguration>
     {
+        /* changing brightness during a period of day had a coupling affect with other period, need further development
         public float morningBrightnessMultiplier { get; set; } = 0f;
         public float dayBrightnessMultiplier { get; set; } = 0f;
         public float eveningBrightnessMultiplier { get; set; } = 0f;
+        */
         public float nightBrightnessMultiplier { get; set; } = 0f;
     }
 }

--- a/ValheimPlus/Configurations/Sections/BrightnessConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/BrightnessConfiguration.cs
@@ -1,0 +1,10 @@
+﻿namespace ValheimPlus.Configurations.Sections
+{
+    public class BrightnessConfiguration : BaseConfig<BrightnessConfiguration>
+    {
+        public float morningBrightnessMultiplier { get; set; } = 0f;
+        public float dayBrightnessMultiplier { get; set; } = 0f;
+        public float eveningBrightnessMultiplier { get; set; } = 0f;
+        public float nightBrightnessMultiplier { get; set; } = 0f;
+    }
+}

--- a/ValheimPlus/Configurations/Sections/GameConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/GameConfiguration.cs
@@ -10,5 +10,6 @@
         public bool disablePortals { get; internal set; } = false;
         public bool forceConsole { get; internal set; } = false;
         public bool bigPortalNames { get; internal set; } = false;
+        public bool disableFog { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -66,4 +66,53 @@ namespace ValheimPlus.GameClasses
         }
         */
     }
+
+    [HarmonyPatch(typeof(EnvMan), "SetEnv")]
+    public static class EnvMan_SetEnv_Patch
+    {
+        private static void Prefix(ref EnvMan __instance, ref EnvSetup env)
+        {
+            if (Configuration.Current.Game.IsEnabled && Configuration.Current.Game.disableFog)
+            {
+                env.m_fogDensityNight = 0.0001f;
+                env.m_fogDensityMorning = 0.0001f;
+                env.m_fogDensityDay = 0.0001f;
+                env.m_fogDensityEvening = 0.0001f;
+            }
+
+            if (Configuration.Current.Brightness.IsEnabled)
+            {
+                applyEnvModifier(env);
+            }
+        }
+
+        private static void applyEnvModifier(EnvSetup env)
+        {
+            env.m_fogColorMorning = applyBrightnessModifier(env.m_fogColorMorning, Configuration.Current.Brightness.morningBrightnessMultiplier);
+            env.m_fogColorSunMorning = applyBrightnessModifier(env.m_fogColorSunMorning, Configuration.Current.Brightness.morningBrightnessMultiplier);
+            env.m_sunColorMorning = applyBrightnessModifier(env.m_sunColorMorning, Configuration.Current.Brightness.morningBrightnessMultiplier);
+
+            env.m_ambColorDay = applyBrightnessModifier(env.m_ambColorDay, Configuration.Current.Brightness.dayBrightnessMultiplier);
+            env.m_fogColorDay = applyBrightnessModifier(env.m_fogColorDay, Configuration.Current.Brightness.dayBrightnessMultiplier);
+            env.m_fogColorSunDay = applyBrightnessModifier(env.m_fogColorSunDay, Configuration.Current.Brightness.dayBrightnessMultiplier);
+            env.m_sunColorDay = applyBrightnessModifier(env.m_sunColorDay, Configuration.Current.Brightness.dayBrightnessMultiplier);
+
+            env.m_fogColorEvening = applyBrightnessModifier(env.m_fogColorEvening, Configuration.Current.Brightness.eveningBrightnessMultiplier);
+            env.m_fogColorSunEvening = applyBrightnessModifier(env.m_fogColorSunEvening, Configuration.Current.Brightness.eveningBrightnessMultiplier);
+            env.m_sunColorEvening = applyBrightnessModifier(env.m_sunColorEvening, Configuration.Current.Brightness.eveningBrightnessMultiplier);
+
+            env.m_ambColorNight = applyBrightnessModifier(env.m_ambColorNight, Configuration.Current.Brightness.nightBrightnessMultiplier);
+            env.m_fogColorNight = applyBrightnessModifier(env.m_fogColorNight, Configuration.Current.Brightness.nightBrightnessMultiplier);
+            env.m_fogColorSunNight = applyBrightnessModifier(env.m_fogColorSunNight, Configuration.Current.Brightness.nightBrightnessMultiplier);
+            env.m_sunColorNight = applyBrightnessModifier(env.m_sunColorNight, Configuration.Current.Brightness.nightBrightnessMultiplier);
+        }
+
+        private static Color applyBrightnessModifier(Color color, float multiplier)
+        {
+            float h, s, v;
+            Color.RGBToHSV(color, out h, out s, out v);
+            v = Mathf.Clamp01(Helper.applyModifierValue(v, multiplier));
+            return Color.HSVToRGB(h, s, v);
+        }
+    }
 }

--- a/ValheimPlus/GameClasses/EnvMan.cs
+++ b/ValheimPlus/GameClasses/EnvMan.cs
@@ -88,6 +88,7 @@ namespace ValheimPlus.GameClasses
 
         private static void applyEnvModifier(EnvSetup env)
         {
+            /* changing brightness during a period of day had a coupling affect with other period, need further development
             env.m_fogColorMorning = applyBrightnessModifier(env.m_fogColorMorning, Configuration.Current.Brightness.morningBrightnessMultiplier);
             env.m_fogColorSunMorning = applyBrightnessModifier(env.m_fogColorSunMorning, Configuration.Current.Brightness.morningBrightnessMultiplier);
             env.m_sunColorMorning = applyBrightnessModifier(env.m_sunColorMorning, Configuration.Current.Brightness.morningBrightnessMultiplier);
@@ -100,6 +101,7 @@ namespace ValheimPlus.GameClasses
             env.m_fogColorEvening = applyBrightnessModifier(env.m_fogColorEvening, Configuration.Current.Brightness.eveningBrightnessMultiplier);
             env.m_fogColorSunEvening = applyBrightnessModifier(env.m_fogColorSunEvening, Configuration.Current.Brightness.eveningBrightnessMultiplier);
             env.m_sunColorEvening = applyBrightnessModifier(env.m_sunColorEvening, Configuration.Current.Brightness.eveningBrightnessMultiplier);
+            */
 
             env.m_ambColorNight = applyBrightnessModifier(env.m_ambColorNight, Configuration.Current.Brightness.nightBrightnessMultiplier);
             env.m_fogColorNight = applyBrightnessModifier(env.m_fogColorNight, Configuration.Current.Brightness.nightBrightnessMultiplier);
@@ -111,7 +113,16 @@ namespace ValheimPlus.GameClasses
         {
             float h, s, v;
             Color.RGBToHSV(color, out h, out s, out v);
-            v = Mathf.Clamp01(Helper.applyModifierValue(v, multiplier));
+            float scaleFunc;
+            if (multiplier >= 0)
+            {
+                scaleFunc = (Mathf.Sqrt(multiplier) * 1.069952679E-4f) + 1f;
+            }
+            else
+            {
+                scaleFunc = 1f - (Mathf.Sqrt(Mathf.Abs(multiplier)) * 1.069952679E-4f);
+            }
+            v = Mathf.Clamp01(v * scaleFunc);
             return Color.HSVToRGB(h, s, v);
         }
     }

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -330,6 +330,7 @@
   <ItemGroup>
     <Compile Include="AdvancedBuildingMode.cs" />
     <Compile Include="AdvancedEditingMode.cs" />
+    <Compile Include="Configurations\Sections\BrightnessConfiguration.cs" />
     <Compile Include="Configurations\Sections\GameClockConfiguration.cs" />
     <Compile Include="Configurations\Sections\MonsterProjectileConfiguration.cs" />
     <Compile Include="Configurations\Sections\PlayerProjectileConfiguration.cs" />

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -939,15 +939,6 @@ textTransparencyChannel=255
 ; Change false to true to enable this section. https://valheim.plus/documentation/list#Brightness
 enabled=true
 
-; Change how bright it looks in the morning. A multiplier (+3) will lead in a big change in brightness. 
-morningBrightnessMultiplier=0
-
-; Change how bright it looks during the day. A multiplier (+3) will lead in a big change in brightness. 
-dayBrightnessMultiplier=0
-
-; Change how bright it looks in the evening. A multiplier (+3) will lead in a big change in brightness. 
-eveningBrightnessMultiplier=0
-
-; Change how bright it looks at night. A multiplier (+3) will lead in a big change in brightness. 
+; Change how bright it looks at night. A multiplier (+100) will result in nearly double in brightness. 
 nightBrightnessMultiplier=0
 

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -933,3 +933,21 @@ textBlueChannel=0
 ; Change how transparent the time text is (255 is solid with no transparency).
 textTransparencyChannel=255
 
+
+[Brightness]
+
+; Change false to true to enable this section. https://valheim.plus/documentation/list#Brightness
+enabled=true
+
+; Change how bright it looks in the morning. A multiplier (+3) will lead in a big change in brightness. 
+morningBrightnessMultiplier=0
+
+; Change how bright it looks during the day. A multiplier (+3) will lead in a big change in brightness. 
+dayBrightnessMultiplier=0
+
+; Change how bright it looks in the evening. A multiplier (+3) will lead in a big change in brightness. 
+eveningBrightnessMultiplier=0
+
+; Change how bright it looks at night. A multiplier (+3) will lead in a big change in brightness. 
+nightBrightnessMultiplier=0
+

--- a/vplusSuggestions/todo.json
+++ b/vplusSuggestions/todo.json
@@ -402,12 +402,6 @@
     "status": "In Consideration",
     "category": "Map"
   },
-  "Remove Fog": {
-    "description": "Add the ability to remove fog from the game.",
-    "icon": "fas fa-fog",
-    "status": "In Consideration",
-    "category": "World"
-  },
   "Remove Ground Height Limits": {
     "description": "Remove/change the limits to how high/low you can dig or build",
     "icon": "fas fa-line-height",

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -642,6 +642,11 @@
 				"description": "If you set this to true, portal names will be displayed in big text in center of screen.",
 				"defaultValue": "false",
 				"defaultType": "bool"
+			},
+			"disableFog": {
+				"description": "Remove dense fog from the game.",
+				"defaultValue": "false",
+				"defaultType": "bool"
 			}
 		}
 	},
@@ -1861,7 +1866,7 @@
 			}
 		}
 	},
-  "Tameable": {
+	"Tameable": {
 		"description": "",
 		"icon": "fas fa-paw",
 		"description_website": "Change the in-game behaviour of creatures tamed by players.",
@@ -1885,7 +1890,39 @@
 				"description": "How long it takes for a tamed creature to recover(in seconds) if mortality is set to 1(essential) and they are stunned.",
 				"defaultValue": "10",
 				"defaultType": "float"
-      }
-    }
-  }
+			}
+		}
+	},
+	"Brightness": {
+		"description": "",
+		"icon": "fas fa-sun",
+		"description_website": "Change the brightness during different time of day.",
+		"entries": {
+			"enabled": {
+				"description": "Change false to true to enable this section.",
+				"defaultType": "bool",
+				"defaultValue": "false"
+			},
+			"morningBrightnessMultiplier": {
+				"description": "Change how bright it looks in the morning. A multiplier (+3) will lead in a big change in brightness.",
+				"defaultValue": "0",
+				"defaultType": "float"
+			},
+			"dayBrightnessMultiplier": {
+				"description": "Change how bright it looks during the day. A multiplier (+3) will lead in a big change in brightness.",
+				"defaultValue": "0",
+				"defaultType": "float"
+			},
+			"eveningBrightnessMultiplier": {
+				"description": "Change how bright it looks in the evening. A multiplier (+3) will lead in a big change in brightness.",
+				"defaultValue": "0",
+				"defaultType": "float"
+			},
+			"nightBrightnessMultiplier": {
+				"description": "Change how bright it looks at night. A multiplier (+3) will lead in a big change in brightness.",
+				"defaultValue": "0",
+				"defaultType": "float"
+			}
+		}
+	}
 }

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -1903,23 +1903,8 @@
 				"defaultType": "bool",
 				"defaultValue": "false"
 			},
-			"morningBrightnessMultiplier": {
-				"description": "Change how bright it looks in the morning. A multiplier (+3) will lead in a big change in brightness.",
-				"defaultValue": "0",
-				"defaultType": "float"
-			},
-			"dayBrightnessMultiplier": {
-				"description": "Change how bright it looks during the day. A multiplier (+3) will lead in a big change in brightness.",
-				"defaultValue": "0",
-				"defaultType": "float"
-			},
-			"eveningBrightnessMultiplier": {
-				"description": "Change how bright it looks in the evening. A multiplier (+3) will lead in a big change in brightness.",
-				"defaultValue": "0",
-				"defaultType": "float"
-			},
 			"nightBrightnessMultiplier": {
-				"description": "Change how bright it looks at night. A multiplier (+3) will lead in a big change in brightness.",
+				"description": "Change how bright it looks at night. A multiplier (+100) will result in nearly double in brightness.",
 				"defaultValue": "0",
 				"defaultType": "float"
 			}


### PR DESCRIPTION
I didn't know a good way to separate the two PR and can be added at the same time, so it will be lumped into one.

1. Add the option to remove fog: #414 
2. It was unplayable sometimes at night (and the sun is out IRL). So here is the option to modify brightness. You can also think of it as a way to change gamma.
  
Brightness was handle by converting all of the base game color to HSV and changing the V (brightness).
