### PR TITLE
Fixed logic error in disableCookingStation when crafting from chest

### DIFF
--- a/ValheimPlus/GameClasses/CookingStation.cs
+++ b/ValheimPlus/GameClasses/CookingStation.cs
@@ -24,7 +24,7 @@ namespace ValheimPlus.GameClasses
         [HarmonyTranspiler]
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            if (!Configuration.Current.CraftFromChest.IsEnabled || !Configuration.Current.CraftFromChest.disableCookingStation) return instructions;
+            if (!Configuration.Current.CraftFromChest.IsEnabled || Configuration.Current.CraftFromChest.disableCookingStation) return instructions;
 
             List<CodeInstruction> il = instructions.ToList();
             int endIdx = -1;


### PR DESCRIPTION
Option was working backwards.