### PR TITLE
[FIX] craft from containers doesn't work with custom containers

### DIFF
--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -27,7 +27,14 @@ namespace ValheimPlus
                     bool hasAccess = foundContainer.CheckAccess(Player.m_localPlayer.GetPlayerID());
                     if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(hitCollider.gameObject.transform.position, 0f, false, true);
                     var piece = foundContainer.GetComponentInParent<Piece>();
-                    if (piece != null && piece.IsPlacedByPlayer() && hasAccess && foundContainer.GetInventory() != null)
+                    var isVagon = foundContainer.GetComponentInParent<Vagon>() != null;
+                    var isShip = foundContainer.GetComponentInParent<Ship>() != null;
+                    if (piece != null
+                        && piece.IsPlacedByPlayer()
+                        && !isVagon
+                        && !isShip
+                        && hasAccess
+                        && foundContainer.GetInventory() != null)
                     {
                         validContainers.Add(foundContainer);
                     }

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -26,7 +26,8 @@ namespace ValheimPlus
                     Container foundContainer = hitCollider.GetComponentInParent<Container>();
                     bool hasAccess = foundContainer.CheckAccess(Player.m_localPlayer.GetPlayerID());
                     if (checkWard) hasAccess = hasAccess && PrivateArea.CheckAccess(hitCollider.gameObject.transform.position, 0f, false, true);
-                    if (foundContainer.m_name.Contains("piece_chest") && hasAccess && foundContainer.GetInventory() != null)
+                    var piece = foundContainer.GetComponentInParent<Piece>();
+                    if (piece != null && piece.IsPlacedByPlayer() && hasAccess && foundContainer.GetInventory() != null)
                     {
                         validContainers.Add(foundContainer);
                     }


### PR DESCRIPTION
Users of [ChestReloaded](https://www.nexusmods.com/valheim/mods/653) mod [say that it doesn't work](https://www.nexusmods.com/valheim/mods/653/?tab=posts&jump_to_comment=92882298) with Valheim+ crafting from containers.

After brief check of your source I found that you're relying on names that was used internally by Iron Gate, but it's not a requirement to create placeable container piece, and pieces added by mod have names that don't contain `piece_chest` string. Other mod authors also may not be aware of it.
Mod authors might change name of their custom containers to follow this convention, but if mod is already published with such names (like, in my case, `SignedChest_ChestReloaded_SignedLocker_AddSignedChestPiece`) and used by players, I can't publish updated version with rename, because all objects created with previous name will be destroyed as invalid prefabs on world start.

At the end, relying on string seems to be too fragile compared to type information and its methods:)