### PR TITLE
Added option to make shared pins be enforced, i.e. NO private pins

### DIFF
--- a/ValheimPlus/Configurations/Sections/MapConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/MapConfiguration.cs
@@ -7,5 +7,6 @@
         public bool preventPlayerFromTurningOffPublicPosition { get; internal set; } = false;
         //public bool useImprovedPinEditorUI { get; internal set; } = false;
         public bool shareablePins { get; internal set; } = false;
+        public bool shareAllPins { get; internal set; } = false;
     }
 }

--- a/ValheimPlus/GameClasses/Minimap.cs
+++ b/ValheimPlus/GameClasses/Minimap.cs
@@ -86,6 +86,16 @@ namespace ValheimPlus.GameClasses
         public static Toggle sharePin;
         public static Vector3 pinPos;
 
+        [HarmonyPatch(typeof(Minimap), nameof(Minimap.AddPin)]
+        public static class Minimap_AddPin_Patch
+        {
+            private static void Postfix(ref Minimap __instance, ref Minimap.PinData __result)
+            {
+                if (Configuration.Current.Map.IsEnabled && Configuration.Current.Map.shareAllPins)
+                    VPlusMapPinSync.SendMapPinToServer(__result);
+            }
+        }
+
         [HarmonyPatch(typeof(Minimap), "Awake")]
         public static class MapPinEditor_Patches_Awake
         {
@@ -93,7 +103,7 @@ namespace ValheimPlus.GameClasses
             {
                 Minimap.PinType pintype = iconSelected.value == 4 ? Minimap.PinType.Icon4 : (Minimap.PinType)iconSelected.value;
                 Minimap.PinData addedPin = __instance.AddPin(pinPos, pintype, pinName.text, true, false);
-                if (Configuration.Current.Map.shareablePins && sharePin.isOn)
+                if (Configuration.Current.Map.shareablePins && sharePin.isOn && !Configuration.Current.Map.shareAllPins)
                     VPlusMapPinSync.SendMapPinToServer(addedPin);
                 pinEditorPanel.SetActive(false);
                 __instance.m_wasFocused = false;
@@ -140,7 +150,7 @@ namespace ValheimPlus.GameClasses
                     sharePin = pinEditorPanel.GetComponentInChildren<Toggle>();
                     if (sharePin != null)
                         Debug.Log("Share pin loaded properly");
-                    if (!Configuration.Current.Map.shareablePins)
+                    if (!Configuration.Current.Map.shareablePins || Configuration.Current.Map.shareAllPins)
                         sharePin.gameObject.SetActive(false);
                 }
             }

--- a/ValheimPlus/RPC/VPlusMapPinSync.cs
+++ b/ValheimPlus/RPC/VPlusMapPinSync.cs
@@ -40,10 +40,13 @@ namespace ValheimPlus.RPC
                     Vector3 pinPos = mapPinPkg.ReadVector3();
                     int pinType = mapPinPkg.ReadInt();
                     string pinName = mapPinPkg.ReadString();
-                    Minimap.PinData addedPin = Minimap.instance.AddPin(pinPos, (Minimap.PinType)pinType, pinName, true, false);
-                    MessageHud.instance.ShowMessage(MessageHud.MessageType.Center, $"Received map pin {pinName} from {senderName}!",
-                        0, Minimap.instance.GetSprite((Minimap.PinType)pinType));
-                    ZLog.Log($"I got pin named {pinName} from {senderName}!");
+                    if (!Minimap.instance.HaveSimilarPin(pinPos, (Minimap.PinType)pinType, pinName, true))
+                    {
+                        Minimap.PinData addedPin = Minimap.instance.AddPin(pinPos, (Minimap.PinType)pinType, pinName, true, false);
+                        MessageHud.instance.ShowMessage(MessageHud.MessageType.Center, $"Received map pin {pinName} from {senderName}!",
+                            0, Minimap.instance.GetSprite((Minimap.PinType)pinType));
+                        ZLog.Log($"I got pin named {pinName} from {senderName}!");
+                    }
                 }
                 //Send Ack
                 VPlusAck.SendAck(sender);

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -551,6 +551,9 @@ preventPlayerFromTurningOffPublicPosition=false
 ; Allow pins to be shared
 shareablePins=false
 
+; Shares all pins always
+shareAllPins=false
+
 
 [Player]
 


### PR DESCRIPTION
Works retroactively for existing pins without modifying data structure