### PR TITLE
Fix filename reference

### DIFF
--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -434,7 +434,7 @@
     <Compile Include="GameClasses\WearNTear.cs" />
     <Compile Include="GameClasses\EnvMan.cs" />
     <Compile Include="GameClasses\Ward.cs" />
-    <Compile Include="GameClasses\InventoryGui.cs" />
+    <Compile Include="GameClasses\InventoryGUI.cs" />
     <Compile Include="GameClasses\CraftingStation.cs" />
     <Compile Include="Utility\Helper.cs" />
     <Compile Include="Utility\ZNetExtensions.cs" />


### PR DESCRIPTION
ValheimPlus/ValheimPlus.csproj references "InventoryGui.cs" but the file is actually "InventoryGUI.cs"
Most filesystems in the world are case sensitive. Even NTFS. Windows holding on to PC-DOS era strangeness is the exception.