### PR TITLE
shareablePins not initialized.

### DIFF
--- a/ValheimPlus/GameClasses/Minimap.cs
+++ b/ValheimPlus/GameClasses/Minimap.cs
@@ -89,7 +89,7 @@ namespace ValheimPlus.GameClasses
         [HarmonyPatch(typeof(Minimap), nameof(Minimap.AddPin))]
         public static class Minimap_AddPin_Patch
         {
-            public static List<Minimap.PinType> shareablePins;
+            public static List<Minimap.PinType> shareablePins = new List<Minimap.PinType>();
 
             private static void Postfix(ref Minimap __instance, ref Minimap.PinData __result)
             {


### PR DESCRIPTION
shareablePins in Minimap_AddPin_Patch is causing null exceptions because it isn't initialized to start.