### PR TITLE
Change difficulty value from multiplier to percent

### DIFF
--- a/ValheimPlus/Configurations/Sections/GameConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/GameConfiguration.cs
@@ -2,8 +2,8 @@
 {
     public class GameConfiguration : ServerSyncConfig<GameConfiguration>
     {
-        public float gameDifficultyDamageScale { get; internal set; } = 0.04f;
-        public float gameDifficultyHealthScale { get; internal set; } = 0.4f;
+        public float gameDifficultyDamageScale { get; internal set; } = 4f;
+        public float gameDifficultyHealthScale { get; internal set; } = 40f;
         public int extraPlayerCountNearby { get; internal set; } = 0;
         public int setFixedPlayerCountTo { get; internal set; } = 0;
         public int difficultyScaleRange { get; internal set; } = 200;

--- a/ValheimPlus/GameClasses/Game.cs
+++ b/ValheimPlus/GameClasses/Game.cs
@@ -35,7 +35,7 @@ namespace ValheimPlus.GameClasses
         private static void Postfix(ref float __result)
         {
             if (Configuration.Current.Game.IsEnabled)
-                __result = ((__result - 1f) / baseDifficultyDamageScale * Configuration.Current.Game.gameDifficultyDamageScale) + 1f;
+                __result = ((__result - 1f) / baseDifficultyDamageScale * Configuration.Current.Game.gameDifficultyDamageScale / 100f) + 1f;
         }
     }
 
@@ -64,7 +64,7 @@ namespace ValheimPlus.GameClasses
         private static void Postfix(ref float __result)
         {
             if (Configuration.Current.Game.IsEnabled)
-                __result = ((__result - 1f) / baseDifficultyHealthScale * Configuration.Current.Game.gameDifficultyHealthScale) + 1f;
+                __result = ((__result - 1f) / baseDifficultyHealthScale * Configuration.Current.Game.gameDifficultyHealthScale / 100f) + 1f;
         }
     }
 

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -340,12 +340,12 @@ allowAllOres=false
 enabled=false
 
 ; The games damage multiplier per person nearby in difficultyScaleRange(m) radius.
-; Default is 0.04, 4% monster damage increase per player in radius.
-gameDifficultyDamageScale=0.04
+; Default is 4% monster damage increase per player in radius.
+gameDifficultyDamageScale=4
 
 ; The games health multiplier per person nearby in difficultyScaleRange(m) radius.
-; Default is 0.40%, 40% monster health increase per player in radius.
-gameDifficultyHealthScale=0.4
+; Default is 40% monster health increase per player in radius.
+gameDifficultyHealthScale=40
 
 ; Adds additional players to the difficulty calculation in multiplayer unrelated to the actual amount.
 ; This option is disabled if its set to 0.

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -626,13 +626,13 @@
 				"defaultType": "bool"
 			},
 			"gameDifficultyDamageScale": {
-				"description": "The games damage multiplier per person nearby in difficultyScaleRange(m) radius.",
-				"defaultValue": "0.04",
+				"description": "The games damage increase in percent per person nearby in difficultyScaleRange(m) radius.",
+				"defaultValue": "4",
 				"defaultType": "float"
 			},
 			"gameDifficultyHealthScale": {
-				"description": "The games health multiplier per person nearby in difficultyScaleRange(m) radius.",
-				"defaultValue": "0.4",
+				"description": "The games health increase in percent per person nearby in difficultyScaleRange(m) radius.",
+				"defaultValue": "40",
 				"defaultType": "float"
 			},
 			"extraPlayerCountNearby": {


### PR DESCRIPTION
This change both `gameDifficultyDamageScale` and `gameDifficultyHealthScale` to percent values instead of the multiplier.

Breaking change that must be communicated when releasing next version.