### PR TITLE
A fix for playerInventoryRows affecting unrelated 8x4 containers

### DIFF
--- a/ValheimPlus/GameClasses/Inventory.cs
+++ b/ValheimPlus/GameClasses/Inventory.cs
@@ -55,7 +55,7 @@ namespace ValheimPlus.GameClasses
             if (Configuration.Current.Inventory.IsEnabled)
             {
                 // Player inventory
-                if (h == 4 && w == 8 || name == "Inventory")
+                if (name == "Grave" || name == "Inventory")
                 {
                     h = Helper.Clamp(Configuration.Current.Inventory.playerInventoryRows, playerInventoryMinRows, playerInventoryMaxRows);
                 }


### PR DESCRIPTION
#646 `playerInventoryRows` should now affect only the player and the tombstone, not every unknown 8x4 container