### PR TITLE
Treat new standing blue torch and Jack-o-turnip the same as other torches

### DIFF
--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -186,8 +186,10 @@ namespace ValheimPlus.GameClasses
             "piece_groundtorch_wood", // standing wood torch
             "piece_groundtorch", // standing iron torch
             "piece_groundtorch_green", // standing green torch
+            "piece_groundtorch_blue", // standing blue torch
             "piece_walltorch", // sconce torch
-            "piece_brazierceiling01" // brazier
+            "piece_brazierceiling01", // brazier
+            "piece_jackoturnip" // Jack-o-turnip
         };
 
         internal static bool IsTorch(string itemName)


### PR DESCRIPTION
Apply fuel consumption/chest-pulling to new Hearth & Home torches in the same way as other light sources.