### PR TITLE
Removed version debug logs

### DIFF
--- a/ValheimPlus/GameClasses/Version.cs
+++ b/ValheimPlus/GameClasses/Version.cs
@@ -14,18 +14,12 @@ namespace ValheimPlus.GameClasses
         {
             private static void Postfix(ref string __result)
             {
-                Debug.Log($"Version generator started.");
                 if (Configuration.Current.Server.IsEnabled)
                 {
                     if (Configuration.Current.Server.enforceMod)
                     {
                         __result = __result + "@" + ValheimPlusPlugin.version;
-                        Debug.Log($"Version generated with enforced mod : {__result}");
                     }
-                }
-                else
-                {
-                    Debug.Log($"Version generated : {__result}");
                 }
             }
         }


### PR DESCRIPTION
The debug logs from the version patch clutter the output log, as no new information is stated. Even worse, when other mods are also changing the version string after V+ the logs are lying.
When a version check occurs, vanilla logs this always with  `ZLog.Log("VERSION check their:" + text + "  mine:" + Version.GetVersionString());`. The additional logs are especially a problem when other mods ask the game version, resulting in even more logs