### PR TITLE
Copy/Paste Item Location in addition to Rotation

### DIFF
--- a/ValheimPlus/AdvancedBuildingMode.cs
+++ b/ValheimPlus/AdvancedBuildingMode.cs
@@ -33,6 +33,7 @@ namespace ValheimPlus
 
         // Save and Load object rotation
         static Quaternion savedRotation;
+        private static Vector3 savedPosition;
 
         public static void Run(ref Player __instance)
         {
@@ -135,13 +136,27 @@ namespace ValheimPlus
             
             changeModificationSpeed();
 
+            // Copying/Pasting
             if (Input.GetKeyUp(Configuration.Current.AdvancedBuildingMode.copyObjectRotation))
             {
                 savedRotation = component.transform.rotation;
+                notifyUser("Copied Rotation");
             }
             if (Input.GetKeyUp(Configuration.Current.AdvancedBuildingMode.pasteObjectRotation))
             {
                 component.transform.rotation = savedRotation;
+                notifyUser("Pasted Rotation");
+            }
+            if (Input.GetKeyUp(Configuration.Current.AdvancedBuildingMode.copyObjectRotationAndPosition))
+            {
+                savedRotation = component.transform.rotation;
+                savedPosition = component.transform.position;
+                notifyUser("Copied Rotation and Position");
+            }
+            if (Input.GetKeyUp(Configuration.Current.AdvancedBuildingMode.pasteObjectRotationAndPosition))
+            {
+                component.transform.SetPositionAndRotation(savedPosition, savedRotation);
+                notifyUser("Pasted Rotation and Position");
             }
 
             var currentRotationAngleDegrees = BASE_ROTATION_ANGLE_DEGREES * currentModificationSpeed;

--- a/ValheimPlus/AdvancedEditingMode.cs
+++ b/ValheimPlus/AdvancedEditingMode.cs
@@ -39,6 +39,7 @@ namespace ValheimPlus
 
         // Save and Load object rotation
         static Quaternion savedRotation;
+        private static Vector3 savedPosition;
 
         // Executing the raycast to find the object
         public static bool ExecuteRayCast(Player playerInstance)
@@ -234,10 +235,23 @@ namespace ValheimPlus
             if (Input.GetKeyUp(Configuration.Current.AdvancedEditingMode.copyObjectRotation))
             {
                 savedRotation = HitPiece.transform.rotation;
+                notifyUser("Copied Rotation");
             }
             if (Input.GetKeyUp(Configuration.Current.AdvancedEditingMode.pasteObjectRotation))
             {
                 HitPiece.transform.rotation = savedRotation;
+                notifyUser("Pasted Rotation");
+            }
+            if (Input.GetKeyUp(Configuration.Current.AdvancedEditingMode.copyObjectRotationAndPosition))
+            {
+                savedRotation = HitPiece.transform.rotation;
+                savedPosition = HitPiece.transform.position;
+                notifyUser("Copied Rotation and Position");
+            }
+            if (Input.GetKeyUp(Configuration.Current.AdvancedEditingMode.pasteObjectRotationAndPosition))
+            {
+                HitPiece.transform.SetPositionAndRotation(savedPosition, savedRotation);
+                notifyUser("Pasted Rotation and Position");
             }
 
             // Maximum distance between player and placed piece

--- a/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedBuildingModeConfiguration.cs
@@ -9,6 +9,8 @@ namespace ValheimPlus.Configurations.Sections
 
         public KeyCode copyObjectRotation { get; internal set; } = KeyCode.Keypad7;
         public KeyCode pasteObjectRotation { get; internal set; } = KeyCode.Keypad8;
+        public KeyCode copyObjectRotationAndPosition { get; internal set; } = KeyCode.Keypad4;
+        public KeyCode pasteObjectRotationAndPosition { get; internal set; } = KeyCode.Keypad5;
 
         public KeyCode increaseScrollSpeed { get; internal set; } = KeyCode.KeypadPlus;
         public KeyCode decreaseScrollSpeed { get; internal set; } = KeyCode.KeypadMinus;

--- a/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/AdvancedEditingModeConfiguration.cs
@@ -12,8 +12,11 @@ namespace ValheimPlus.Configurations.Sections
         public KeyCode resetAdvancedEditingMode { get; internal set; } = KeyCode.F7;
         public KeyCode abortAndExitAdvancedEditingMode { get; internal set; } =  KeyCode.F8;
         public KeyCode confirmPlacementOfAdvancedEditingMode { get; internal set; } = KeyCode.KeypadEnter;
+        
         public KeyCode copyObjectRotation { get; internal set; } = KeyCode.Keypad7;
         public KeyCode pasteObjectRotation { get; internal set; } = KeyCode.Keypad8;
+        public KeyCode copyObjectRotationAndPosition { get; internal set; } = KeyCode.Keypad4;
+        public KeyCode pasteObjectRotationAndPosition { get; internal set; } = KeyCode.Keypad5;
 
         public KeyCode increaseScrollSpeed { get; internal set; } = KeyCode.KeypadPlus;
         public KeyCode decreaseScrollSpeed { get; internal set; } = KeyCode.KeypadMinus;

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -27,6 +27,12 @@ copyObjectRotation=Keypad7
 ; Apply the copied object rotation to the currently selected object in ABM
 pasteObjectRotation=Keypad8
 
+; Copy the object rotation and position of the currently selected object in ABM
+copyObjectRotationAndPosition=Keypad4
+
+; Apply the copied object rotation and position to the currently selected object in ABM
+pasteObjectRotationAndPosition=Keypad5
+
 ; Increases the amount an object rotates and moves. Holding Shift will increase in increments of 10 instead of 1.
 increaseScrollSpeed=KeypadPlus
 
@@ -56,6 +62,12 @@ copyObjectRotation=Keypad7
 
 ; Apply the copied object rotation to the currently selected object in AEM
 pasteObjectRotation=Keypad8
+
+; Copy the object rotation and position of the currently selected object in ABM
+copyObjectRotationAndPosition=Keypad4
+
+; Apply the copied object rotation and position to the currently selected object in ABM
+pasteObjectRotationAndPosition=Keypad5
 
 ; Increases the amount an object rotates and moves. Holding Shift will increase in increments of 10 instead of 1.
 increaseScrollSpeed=KeypadPlus

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -46,6 +46,17 @@
 				"defaultValue": "Keypad8",
 				"defaultType": "KeyCode"
 			},
+			
+			"copyObjectRotationAndPosition": {
+				"description": "Copy the object rotation and position of the currently selected object in ABM",
+				"defaultValue": "Keypad4",
+				"defaultType": "KeyCode"
+			},
+			"pasteObjectRotationAndPosition": {
+				"description": "Apply the copied object rotation and position to the currently selected object in ABM",
+				"defaultValue": "Keypad5",
+				"defaultType": "KeyCode"
+			},
 			"increaseScrollSpeed": {
 				"description": "Increases the amount an object rotates and moves. Holding Shift will increase in increments of 10 instead of 1.",
 				"defaultValue": "KeypadPlus",
@@ -96,6 +107,16 @@
 			"pasteObjectRotation": {
 				"description": "Apply the copied object rotation to the currently selected object in AEM",
 				"defaultValue": "Keypad8",
+				"defaultType": "KeyCode"
+			},
+			"copyObjectRotationAndPosition": {
+				"description": "Copy the object rotation and position of the currently selected object in AEM",
+				"defaultValue": "Keypad4",
+				"defaultType": "KeyCode"
+			},
+			"pasteObjectRotationAndPosition": {
+				"description": "Apply the copied object rotation and position to the currently selected object in AEM",
+				"defaultValue": "Keypad5",
 				"defaultType": "KeyCode"
 			},
 			"increaseScrollSpeed": {


### PR DESCRIPTION
https://github.com/valheimPlus/ValheimPlus/issues/755

This helps a building workflow when building multiple pieces at odd angles as you can immediately pick up from where your previous piece left off instead of struggling to try to get the next piece lined up when your initial anchor may have been different.

I also made the minor change to add a top-left message indicating things had been copied/pasted, as it bothered me before that I didn't know if the keystroke had been recognized or not.