### PR TITLE
Add new Mistlands update skills

### DIFF
--- a/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/ExperienceConfiguration.cs
@@ -15,10 +15,12 @@
 		public float unarmed { get; internal set; } = 0;
 		public float pickaxes { get; internal set; } = 0;
 		public float woodCutting { get; internal set; } = 0;
+		public float crossbows { get; internal set; } = 0;
 		public float jump { get; internal set; } = 0;
 		public float sneak { get; internal set; } = 0;
 		public float run { get; internal set; } = 0;
 		public float swim { get; internal set; } = 0;
+		public float fishing { get; internal set; } = 0;
 		public float ride { get; internal set; } = 0;
 
 	}

--- a/ValheimPlus/GameClasses/Skills.cs
+++ b/ValheimPlus/GameClasses/Skills.cs
@@ -117,10 +117,12 @@ namespace ValheimPlus.GameClasses
 		Unarmed,
 		Pickaxes,
 		WoodCutting,
+		Crossbows,
 		Jump = 100,
 		Sneak,
 		Run,
 		Swim,
+		Fishing,
 		Ride = 110,
 		All = 999
 	}

--- a/ValheimPlus/GameClasses/Skills.cs
+++ b/ValheimPlus/GameClasses/Skills.cs
@@ -58,6 +58,9 @@ namespace ValheimPlus.GameClasses
 					case SkillType.WoodCutting:
 						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.woodCutting);
 						break;
+					case SkillType.Crossbows:
+						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.crossbows);
+						break;
 					case SkillType.Jump:
 						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.jump);
 						break;
@@ -69,6 +72,9 @@ namespace ValheimPlus.GameClasses
 						break;
 					case SkillType.Swim:
 						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.swim);
+						break;
+					case SkillType.Fishing:
+						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.fishing);
 						break;
 					case SkillType.Ride:
 						factor = Helper.applyModifierValue(factor, Configuration.Current.Experience.ride);


### PR DESCRIPTION
Added Fishing and Crossbows. Without them character save is not possible.

Worth noticing is Valheim is using ElementalMagic and BloodMagic skill names instead of FireMagic and FrostMagic, but that is not breaking code, so leaving it alone for now.
