### PR TITLE
Adding LootDrop section with modifiers for loot amount and chance

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ We work together closely to make sure all our features are integrated and workin
 * Modify velocity and accuracy of projectiles from monsters.
 * Modify damage and health scaling of monsters in multiplayer based on player count.
 
+### Loot
+* Modify the chance and amount of loot dropped.
+
 # Server
 * Remove password requirement for the server.
 * Modify the maximum amount of players on a server.

--- a/ValheimPlus/Configurations/Configuration.cs
+++ b/ValheimPlus/Configurations/Configuration.cs
@@ -53,5 +53,6 @@ namespace ValheimPlus.Configurations
         public GameClockConfiguration GameClock { get; set; }
         public BrightnessConfiguration Brightness { get; set; }
         public ChatConfiguration Chat { get; set; }
+        public LootDropConfiguration LootDrop { get; set; }
     }
 }

--- a/ValheimPlus/Configurations/Sections/LootDropConfiguration.cs
+++ b/ValheimPlus/Configurations/Sections/LootDropConfiguration.cs
@@ -1,0 +1,8 @@
+namespace ValheimPlus.Configurations.Sections
+{
+    public class LootDropConfiguration : ServerSyncConfig<LootDropConfiguration>
+    {
+        public float lootDropAmountMultiplier { get; internal set; } = 0;
+        public float lootDropChanceMultiplier { get; internal set; } = 0;
+    }
+}

--- a/ValheimPlus/GameClasses/CharacterDrop.cs
+++ b/ValheimPlus/GameClasses/CharacterDrop.cs
@@ -1,0 +1,44 @@
+using HarmonyLib;
+using UnityEngine;
+using System.Collections.Generic;
+using ValheimPlus.Configurations;
+using System;
+
+namespace ValheimPlus
+{
+    /// <summary>
+    /// Modify drops to increase their amount and chances.
+    /// </summary>
+    [HarmonyPatch(typeof(CharacterDrop), nameof(CharacterDrop.GenerateDropList))]
+    public static class CharacterDrop_GenerateDropList_Patch
+    {
+        private static bool Prefix(ref List<CharacterDrop.Drop> ___m_drops, ref List<CharacterDrop.Drop> __state)
+        {
+            if (Configuration.Current.LootDrop.IsEnabled)
+            {
+                __state = ___m_drops;
+                ___m_drops = ___m_drops.ConvertAll(originalDrop => {
+                    var newDrop = new CharacterDrop.Drop
+                    {
+                        m_prefab = originalDrop.m_prefab,
+                        m_amountMin = (int)Helper.applyModifierValue(originalDrop.m_amountMin, Configuration.Current.LootDrop.lootDropAmountMultiplier),
+                        m_amountMax = (int)Helper.applyModifierValue(originalDrop.m_amountMax, Configuration.Current.LootDrop.lootDropAmountMultiplier),
+                        m_chance = Helper.applyModifierValue(originalDrop.m_chance, Configuration.Current.LootDrop.lootDropChanceMultiplier),
+                        m_onePerPlayer = originalDrop.m_onePerPlayer,
+                        m_levelMultiplier = originalDrop.m_levelMultiplier
+                    };
+                    return newDrop;
+                });
+            }
+            return true;
+        }
+
+        private static void Postfix(ref List<CharacterDrop.Drop> ___m_drops, List<CharacterDrop.Drop> __state)
+        {
+            if (Configuration.Current.LootDrop.IsEnabled)
+            {
+                ___m_drops = __state;
+            }
+        }
+    }
+}

--- a/ValheimPlus/ValheimPlus.csproj
+++ b/ValheimPlus/ValheimPlus.csproj
@@ -39,7 +39,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-	<Reference Include="netstandard" />
+    <Reference Include="netstandard" />
     <Reference Include="0Harmony, Version=2.10.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HarmonyX.2.10.0\lib\net45\0Harmony.dll</HintPath>
     </Reference>
@@ -344,6 +344,7 @@
     <Compile Include="Configurations\Sections\BrightnessConfiguration.cs" />
     <Compile Include="Configurations\Sections\ChatConfiguration.cs" />
     <Compile Include="Configurations\Sections\GameClockConfiguration.cs" />
+    <Compile Include="Configurations\Sections\LootDropConfiguration.cs" />
     <Compile Include="Configurations\Sections\MonsterProjectileConfiguration.cs" />
     <Compile Include="Configurations\Sections\PlayerProjectileConfiguration.cs" />
     <Compile Include="Configurations\Sections\CraftFromChestConfiguration.cs" />
@@ -396,6 +397,7 @@
     <Compile Include="Configurations\Sections\StaminaUsageConfiguration.cs" />
     <Compile Include="Configurations\Sections\StaminaConfiguration.cs" />
     <Compile Include="GameClasses\Character.cs" />
+    <Compile Include="GameClasses\CharacterDrop.cs" />
     <Compile Include="GameClasses\SEMan.cs" />
     <Compile Include="GameClasses\Talker.cs" />
     <Compile Include="GameClasses\Container.cs" />

--- a/valheim_plus.cfg
+++ b/valheim_plus.cfg
@@ -1110,3 +1110,19 @@ defaultNormalDistance = 15
 
 ; This value determines the range in meters that you can see shout text messages by default.
 defaultShoutDistance = 70
+
+
+[LootDrop]
+
+; Change false to true to enable this section, if you set this to false the mode will not be accesible
+enabled=false
+
+; Change the amount of loot dropped when creatures or monsters are slain. 
+; A value of -100 will eliminate all drops, 0 will have no effect, 100 will double drops, 200 will triple and so on.
+lootDropAmountMultiplier=0
+
+; Change the chance of loot dropping when creatures or monsters are slain. 
+; A value of -100 will eliminate all drops, 0 will have no effect, 100 will double the percent of getting a drop, 200 will triple and so on.
+; Example: If a drop has a 40% chance, setting this to 200 will make that chance 80%, 
+;          and setting it to 300 will make it 100% (120% technically, but anything above 100% acts as 100%)
+lootDropChanceMultiplier=0

--- a/vplusconfig.json
+++ b/vplusconfig.json
@@ -2070,5 +2070,29 @@
 				"defaultType": "float"
 			}
 		}
+	},
+	"LootDrop": {
+		"description": "",
+		"icon": "fa fa-treasure-chest",
+		"description_website": "Change the chance and amount of loot dropped when creatures are slain.",
+		"entries": {
+			"enabled": {
+				"description": "Change false to true to enable this section",
+				"defaultValue": "false",
+				"defaultType": "bool"
+			},
+			"lootDropAmountMultiplier": {
+				"description": "The value 100 will double the amount of dropped loot, 200 will triple. Smaller values such as 50 only has an effect if more than 1 item would drop normally.",
+				"defaultValue": "0",
+				"defaultType": "float",
+				"modifier": "true"
+			},
+			"lootDropChanceMultiplier": {
+				"description": "The value 100 will double the percentage chance of drop, 200 will triple.",
+				"defaultValue": "0",
+				"defaultType": "float",
+				"modifier": "true"
+			}
+		}
 	}
 }


### PR DESCRIPTION
This adds a configuration which will change the amount of loot dropped by creatures/monsters when they are slain.