### PR TITLE
Fix bug where fishing with PlayerProjectile.enableScaleWithSkillLevel causes inability to save

### DIFF
--- a/ValheimPlus/GameClasses/Attack.cs
+++ b/ValheimPlus/GameClasses/Attack.cs
@@ -90,15 +90,19 @@ namespace ValheimPlus.GameClasses
                 if (Configuration.Current.PlayerProjectile.enableScaleWithSkillLevel)
                 {
 
-                    Player player = (Player)__instance.m_character;
-                    Skills.Skill skill = player.m_skills.GetSkill(__instance.m_weapon.m_shared.m_skillType);
-                    float maxLevelPercentage = skill.m_level * 0.01f;
+                    Skills.SkillType skillType = __instance.m_weapon.m_shared.m_skillType;
+                    if (skillType != Skills.SkillType.None) // https://github.com/valheimPlus/ValheimPlus/issues/758
+                    {
+                        Player player = (Player)__instance.m_character;
+                        Skills.Skill skill = player.m_skills.GetSkill(skillType);
+                        float maxLevelPercentage = skill.m_level * 0.01f;
 
-                    __instance.m_projectileVelMin = Mathf.Lerp(__instance.m_projectileVelMin, playerProjVelMinMod, maxLevelPercentage);
-                    __instance.m_projectileVel = Mathf.Lerp(__instance.m_projectileVel, playerProjVelMaxMod, maxLevelPercentage);
+                        __instance.m_projectileVelMin = Mathf.Lerp(__instance.m_projectileVelMin, playerProjVelMinMod, maxLevelPercentage);
+                        __instance.m_projectileVel = Mathf.Lerp(__instance.m_projectileVel, playerProjVelMaxMod, maxLevelPercentage);
 
-                    __instance.m_projectileAccuracyMin = Mathf.Lerp(__instance.m_projectileAccuracyMin, playerProjAccuMinMod, maxLevelPercentage);
-                    __instance.m_projectileAccuracy = Mathf.Lerp(__instance.m_projectileAccuracy, playerProjAccuMaxMod, maxLevelPercentage);
+                        __instance.m_projectileAccuracyMin = Mathf.Lerp(__instance.m_projectileAccuracyMin, playerProjAccuMinMod, maxLevelPercentage);
+                        __instance.m_projectileAccuracy = Mathf.Lerp(__instance.m_projectileAccuracy, playerProjAccuMaxMod, maxLevelPercentage);
+                    }
                 }
                 else
                 {

--- a/ValheimPlus/GameClasses/Skills.cs
+++ b/ValheimPlus/GameClasses/Skills.cs
@@ -1,9 +1,9 @@
 ﻿using HarmonyLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using ValheimPlus.Configurations;
-using ValheimPlus.Utility;
 
 namespace ValheimPlus.GameClasses
 {
@@ -84,7 +84,7 @@ namespace ValheimPlus.GameClasses
 		/// </summary>
 		private static void Postfix(Skills __instance, Skills.SkillType skillType, float factor = 1f)
 		{
-			if (Configuration.Current.Hud.IsEnabled && Configuration.Current.Hud.experienceGainedNotifications)
+			if (Configuration.Current.Hud.IsEnabled && Configuration.Current.Hud.experienceGainedNotifications && skillType != Skills.SkillType.None)
 			{
 				try
                 {
@@ -95,8 +95,11 @@ namespace ValheimPlus.GameClasses
 						+ " [" + Helper.tFloat(skill.m_accumulator, 2) + "/" + Helper.tFloat(skill.GetNextLevelRequirement(), 2) + "]"
 						+ " (" + Helper.tFloat(percent, 0) + "%)", 0, skill.m_info.m_icon);
 				}
-				catch
-                { return; }
+				catch (Exception ex)
+				{
+					ZLog.LogError(ex);
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This fixes #758. I reproduced save not working before this change and working afterwards.

The issue is that `__instance.m_weapon.m_shared.m_skillType` is `None` for the fishing rod. Casting the rod triggers `ProjectileAttackTriggered`, which then calls `player.m_skills.GetSkill(skillType)` with a `skillType` of `None`. When `GetSkill` doesn't find an existing skill for `None`, it creates a new one for `None` with 0 xp and level as well as null `m_info`. This is added to the list of skills to later be saved.  When `Skill.Save` is called there is a line of code which tries to read `skill.m_info.m_skill`, which causes the `NullReferenceException`, since `skill.m_info` is `null`.

The fix ensures we skip calling `GetSkill` when `skillType` is `None`.

I also added this check to the other place where `GetSkill` is called, just in case.