### PR TITLE
feat: changed version string patch to include the mod name

### DIFF
--- a/ValheimPlus/GameClasses/Version.cs
+++ b/ValheimPlus/GameClasses/Version.cs
@@ -18,7 +18,7 @@ namespace ValheimPlus.GameClasses
                 {
                     if (Configuration.Current.Server.enforceMod)
                     {
-                        __result = __result + "@" + ValheimPlusPlugin.version;
+                        __result += $"-ValheimPlus@{ValheimPlusPlugin.version}";
                     }
                 }
             }


### PR DESCRIPTION
Closes #779.
As already discussed, this makes it more clear for new players and other modders which mod is changing the version string. As this string even changes with every V+ patch version completely and needs to be equal on all players, it is compatible with the current version check.