### PR TITLE
Refactoring container interactions to avoid overwriting adds/removes

### DIFF
--- a/ValheimPlus/GameClasses/Beehive.cs
+++ b/ValheimPlus/GameClasses/Beehive.cs
@@ -141,10 +141,10 @@ namespace ValheimPlus.GameClasses
                     Inventory cInventory = chest.GetInventory();
                     if (mustHaveItem && !cInventory.HaveItem(item.m_itemData.m_shared.m_name))
                         continue;
-                    if (chest.IsInUse())
+                    if (!chest.IsOwner() || chest.IsInUse())
                         continue;
 
-                    using (InventoryAssistant.lockContainer(chest))
+                    using (InventoryAssistant.LockContainer(chest))
                     {
                         if (!cInventory.AddItem(item.m_itemData))
                         {
@@ -229,10 +229,10 @@ namespace ValheimPlus.GameClasses
                     Inventory cInventory = chest.GetInventory();
                     if (mustHaveItem && !cInventory.HaveItem(item.m_itemData.m_shared.m_name))
                         continue;
-                    if (chest.IsInUse())
+                    if (!chest.IsOwner() || chest.IsInUse())
                         continue;
 
-                    using (InventoryAssistant.lockContainer(chest))
+                    using (InventoryAssistant.LockContainer(chest))
                     {
                         if (!cInventory.AddItem(item.m_itemData))
                         {

--- a/ValheimPlus/GameClasses/Beehive.cs
+++ b/ValheimPlus/GameClasses/Beehive.cs
@@ -1,10 +1,12 @@
 using HarmonyLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using UnityEngine;
 using ValheimPlus.Configurations;
+using Object = UnityEngine.Object;
 
 namespace ValheimPlus.GameClasses
 {
@@ -98,7 +100,7 @@ namespace ValheimPlus.GameClasses
             if (!Configuration.Current.Beehive.autoDeposit || !Configuration.Current.Beehive.IsEnabled || !beehive.m_nview.IsOwner())
                 return true;
 
-            // if behive is empty
+            // if beehive is empty
             if (beehive.GetHoneyLevel() <= 0)
                 return true;
 
@@ -139,15 +141,20 @@ namespace ValheimPlus.GameClasses
                     Inventory cInventory = chest.GetInventory();
                     if (mustHaveItem && !cInventory.HaveItem(item.m_itemData.m_shared.m_name))
                         continue;
-
-                    if (!cInventory.AddItem(item.m_itemData))
-                    {
-                        //Chest full, move to the next
+                    if (chest.IsInUse())
                         continue;
+
+                    using (InventoryAssistant.lockContainer(chest))
+                    {
+                        if (!cInventory.AddItem(item.m_itemData))
+                        {
+                            //Chest full, move to the next
+                            continue;
+                        }
+                        beehive.m_nview.GetZDO().Set("level", beehive.GetHoneyLevel() - 1);
+                        InventoryAssistant.ConveyContainerToNetwork(chest);
+                        return true;
                     }
-                    beehive.m_nview.GetZDO().Set("level", beehive.GetHoneyLevel() - 1);
-                    InventoryAssistant.ConveyContainerToNetwork(chest);
-                    return true;
                 }
 
                 if (mustHaveItem)
@@ -222,15 +229,20 @@ namespace ValheimPlus.GameClasses
                     Inventory cInventory = chest.GetInventory();
                     if (mustHaveItem && !cInventory.HaveItem(item.m_itemData.m_shared.m_name))
                         continue;
-
-                    if (!cInventory.AddItem(item.m_itemData))
-                    {
-                        //Chest full, move to the next
+                    if (chest.IsInUse())
                         continue;
+
+                    using (InventoryAssistant.lockContainer(chest))
+                    {
+                        if (!cInventory.AddItem(item.m_itemData))
+                        {
+                            //Chest full, move to the next
+                            continue;
+                        }
+                        beehive.m_nview.GetZDO().Set("level", beehive.GetHoneyLevel() - 1);
+                        InventoryAssistant.ConveyContainerToNetwork(chest);
+                        return true;
                     }
-                    beehive.m_nview.GetZDO().Set("level", beehive.GetHoneyLevel() - 1);
-                    InventoryAssistant.ConveyContainerToNetwork(chest);
-                    return true;
                 }
 
                 if (mustHaveItem)

--- a/ValheimPlus/GameClasses/CookingStation.cs
+++ b/ValheimPlus/GameClasses/CookingStation.cs
@@ -71,10 +71,8 @@ namespace ValheimPlus.GameClasses
 
                 foreach (Container c in nearbyChests)
                 {
-                    if (c.GetInventory().HaveItem(itemData.m_shared.m_name))
+                    if (InventoryAssistant.RemoveItemFromChest(c, itemData) >= 1) // remove 1 item from chest
                     {
-                        // Remove one item from chest
-                        InventoryAssistant.RemoveItemFromChest(c, itemData);
                         // Instantiate cookabled GameObject
                         GameObject itemPrefab = ObjectDB.instance.GetItemPrefab(itemConversion.m_from.gameObject.name);
 

--- a/ValheimPlus/GameClasses/Fermenter.cs
+++ b/ValheimPlus/GameClasses/Fermenter.cs
@@ -263,9 +263,9 @@ namespace ValheimPlus.GameClasses
                     Inventory cInventory = chest.GetInventory();
                     if (mustHaveItem && !cInventory.HaveItem(item.m_itemData.m_shared.m_name))
                         continue;
-                    if (chest.IsInUse()) 
+                    if (!chest.IsOwner() || chest.IsInUse()) 
                         continue;
-                    using (InventoryAssistant.lockContainer(chest))
+                    using (InventoryAssistant.LockContainer(chest))
                     {
                         if (!cInventory.AddItem(item.m_itemData))
                         {

--- a/ValheimPlus/GameClasses/Fermenter.cs
+++ b/ValheimPlus/GameClasses/Fermenter.cs
@@ -263,16 +263,20 @@ namespace ValheimPlus.GameClasses
                     Inventory cInventory = chest.GetInventory();
                     if (mustHaveItem && !cInventory.HaveItem(item.m_itemData.m_shared.m_name))
                         continue;
-
-                    if (!cInventory.AddItem(item.m_itemData))
-                    {
-                        //Chest full, move to the next
+                    if (chest.IsInUse()) 
                         continue;
+                    using (InventoryAssistant.lockContainer(chest))
+                    {
+                        if (!cInventory.AddItem(item.m_itemData))
+                        {
+                            //Chest full, move to the next
+                            continue;
+                        }
+
+                        InventoryAssistant.ConveyContainerToNetwork(chest);
+
+                        return true;
                     }
-
-                    InventoryAssistant.ConveyContainerToNetwork(chest);
-
-                    return true;
                 }
 
                 if (mustHaveItem)

--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -168,7 +168,7 @@ namespace ValheimPlus.GameClasses
 
             foreach (Container c in nearbyChests)
             {
-                if (!c.IsInUse() && c.GetInventory().HaveItem(item.m_shared.m_name))
+                if (c.IsOwner() && !c.IsInUse() && c.GetInventory().HaveItem(item.m_shared.m_name))
                 {
                     inventory = c.GetInventory();
                     return true;

--- a/ValheimPlus/GameClasses/Fireplace.cs
+++ b/ValheimPlus/GameClasses/Fireplace.cs
@@ -168,7 +168,7 @@ namespace ValheimPlus.GameClasses
 
             foreach (Container c in nearbyChests)
             {
-                if (c.GetInventory().HaveItem(item.m_shared.m_name))
+                if (!c.IsInUse() && c.GetInventory().HaveItem(item.m_shared.m_name))
                 {
                     inventory = c.GetInventory();
                     return true;

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -272,7 +272,7 @@ namespace ValheimPlus.GameClasses
 
             foreach (Container chest in nearbyChests)
             {
-                if (chest.IsInUse())
+                if (!chest.IsOwner() || chest.IsInUse())
                     continue;
                 found = player.GetFirstRequiredItem(chest.GetInventory(), recipe, quality, out quantity, out extraAmount);
                 if (found != null)
@@ -304,7 +304,7 @@ namespace ValheimPlus.GameClasses
                 Inventory chestInventory = chest.GetInventory();
                 if (chestInventory.CountItems(itemName, quality) > 0)
                 {
-                    using (InventoryAssistant.lockContainer(chest))
+                    using (InventoryAssistant.LockContainer(chest))
                     {
                         toRemove -= InventoryAssistant.RemoveItemFromChest(chest, itemName, toRemove);
                     }

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -261,7 +261,8 @@ namespace ValheimPlus.GameClasses
 
         private static ItemDrop.ItemData GetFirstRequiredItemFromInventoryOrChest(Player player, Recipe recipe, int quality, out int quantity)
         {
-            ItemDrop.ItemData found = player.GetFirstRequiredItem(player.GetInventory(), recipe, quality, out quantity);
+            int extraAmount;
+            ItemDrop.ItemData found = player.GetFirstRequiredItem(player.GetInventory(), recipe, quality, out quantity, out extraAmount);
             if (found != null) return found;
 
             GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
@@ -271,7 +272,9 @@ namespace ValheimPlus.GameClasses
 
             foreach (Container chest in nearbyChests)
             {
-                found = player.GetFirstRequiredItem(chest.GetInventory(), recipe, quality, out quantity);
+                if (chest.IsInUse())
+                    continue;
+                found = player.GetFirstRequiredItem(chest.GetInventory(), recipe, quality, out quantity, out extraAmount);
                 if (found != null)
                 {
                     return found;
@@ -301,7 +304,10 @@ namespace ValheimPlus.GameClasses
                 Inventory chestInventory = chest.GetInventory();
                 if (chestInventory.CountItems(itemName, quality) > 0)
                 {
-                    toRemove -= InventoryAssistant.RemoveItemFromChest(chest, itemName, toRemove);
+                    using (InventoryAssistant.lockContainer(chest))
+                    {
+                        toRemove -= InventoryAssistant.RemoveItemFromChest(chest, itemName, toRemove);
+                    }
                     if (toRemove == 0) return;
                 }
             }

--- a/ValheimPlus/GameClasses/Smelter.cs
+++ b/ValheimPlus/GameClasses/Smelter.cs
@@ -117,17 +117,21 @@ namespace ValheimPlus.GameClasses
                         Inventory cInventory = chest.GetInventory();
                         if (mustHaveItem && !cInventory.HaveItem(comp.m_itemData.m_shared.m_name))
                             continue;
-
-                        bool added = cInventory.AddItem(comp.m_itemData);
-                        if (!added)
-                        {
-                            // Chest full, move to the next
+                        if (chest.IsInUse()) 
                             continue;
-                        }
+                        using (InventoryAssistant.lockContainer(chest))
+                        {
+                            bool added = cInventory.AddItem(comp.m_itemData);
+                            if (!added)
+                            {
+                                // Chest full, move to the next
+                                continue;
+                            }
 
-                        smelter.m_produceEffects.Create(smelter.transform.position, smelter.transform.rotation, null, 1f);
-                        InventoryAssistant.ConveyContainerToNetwork(chest);
-                        return false;
+                            smelter.m_produceEffects.Create(smelter.transform.position, smelter.transform.rotation, null, 1f);
+                            InventoryAssistant.ConveyContainerToNetwork(chest);
+                            return false;
+                        }
                     }
 
                     if (mustHaveItem)

--- a/ValheimPlus/GameClasses/Smelter.cs
+++ b/ValheimPlus/GameClasses/Smelter.cs
@@ -117,9 +117,9 @@ namespace ValheimPlus.GameClasses
                         Inventory cInventory = chest.GetInventory();
                         if (mustHaveItem && !cInventory.HaveItem(comp.m_itemData.m_shared.m_name))
                             continue;
-                        if (chest.IsInUse()) 
+                        if (!chest.IsOwner() || chest.IsInUse()) 
                             continue;
-                        using (InventoryAssistant.lockContainer(chest))
+                        using (InventoryAssistant.LockContainer(chest))
                         {
                             bool added = cInventory.AddItem(comp.m_itemData);
                             if (!added)

--- a/ValheimPlus/Utility/InventoryAssistant.cs
+++ b/ValheimPlus/Utility/InventoryAssistant.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using ValheimPlus.Configurations;
@@ -81,26 +82,26 @@ namespace ValheimPlus
         /// <summary>
         /// Check if the container contains the itemInfo.m_shared.name (item name)
         /// </summary>
-        public static bool ChestContainsItem(Container chest, ItemDrop.ItemData needle)
+        public static bool ChestContainsItem(Container chest, ItemDrop.ItemData itemDataToFind)
         {
             List<ItemDrop.ItemData> items = chest.GetInventory().GetAllItems();
 
             foreach (ItemDrop.ItemData item in items)
             {
-                if (item.m_shared.m_name == needle.m_shared.m_name)
+                if (item.m_shared.m_name == itemDataToFind.m_shared.m_name)
                     return true;
             }
 
             return false;
         }
 
-        public static bool ChestContainsItem(Container chest, string needle)
+        public static bool ChestContainsItem(Container chest, string itemNameToFind)
         {
             List<ItemDrop.ItemData> items = chest.GetInventory().GetAllItems();
 
             foreach (ItemDrop.ItemData item in items)
             {
-                if (item.m_shared.m_name == needle)
+                if (item.m_shared.m_name == itemNameToFind)
                     return true;
             }
 
@@ -145,31 +146,31 @@ namespace ValheimPlus
         /// <summary>
         /// function to get the amount of a specific item in a list of <ItemDrop.ItemData>
         /// </summary>
-        public static int GetItemAmountInItemList(List<ItemDrop.ItemData> itemList, ItemDrop.ItemData needle)
+        public static int GetItemAmountInItemList(List<ItemDrop.ItemData> itemList, ItemDrop.ItemData itemDataToFind)
         {
             int amount = 0;
             foreach (ItemDrop.ItemData item in itemList)
             {
-                if (item.m_shared.m_name == needle.m_shared.m_name)
+                if (item.m_shared.m_name == itemDataToFind.m_shared.m_name)
                     amount += item.m_stack;
             }
 
             return amount;
         }
 
-        public static int GetItemAmountInItemList(List<ItemDrop.ItemData> itemList, string needle)
+        public static int GetItemAmountInItemList(List<ItemDrop.ItemData> itemList, string itemNameToFind)
         {
             int amount = 0;
             foreach (ItemDrop.ItemData item in itemList)
             {
-                if (item.m_shared.m_name == needle) amount += item.m_stack;
+                if (item.m_shared.m_name == itemNameToFind) amount += item.m_stack;
             }
 
             return amount;
         }
 
         // function to remove items in the amount from all nearby chests
-        public static int RemoveItemInAmountFromAllNearbyChests(GameObject target, float range, ItemDrop.ItemData needle, int amount, bool checkWard = true)
+        public static int RemoveItemInAmountFromAllNearbyChests(GameObject target, float range, ItemDrop.ItemData itemDataToRemove, int amount, bool checkWard = true)
         {
             List<Container> nearbyChests = GetNearbyChests(target, range, checkWard);
 
@@ -177,7 +178,7 @@ namespace ValheimPlus
             List<ItemDrop.ItemData> allItems = GetNearbyChestItemsByContainerList(nearbyChests);
 
             // get amount of item
-            int availableAmount = GetItemAmountInItemList(allItems, needle);
+            int availableAmount = GetItemAmountInItemList(allItems, itemDataToRemove);
 
             // check if there are enough items
             if (amount == 0)
@@ -189,7 +190,7 @@ namespace ValheimPlus
             {
                 if (itemsRemovedTotal != amount)
                 {
-                    int removedItems = RemoveItemFromChest(chest, needle, amount);
+                    int removedItems = RemoveItemFromChest(chest, itemDataToRemove, amount);
                     itemsRemovedTotal += removedItems;
                     amount -= removedItems;
                 }
@@ -198,7 +199,7 @@ namespace ValheimPlus
             return itemsRemovedTotal;
         }
 
-        public static int RemoveItemInAmountFromAllNearbyChests(GameObject target, float range, string needle, int amount, bool checkWard = true)
+        public static int RemoveItemInAmountFromAllNearbyChests(GameObject target, float range, string itemNameToRemove, int amount, bool checkWard = true)
         {
             List<Container> nearbyChests = GetNearbyChests(target, range, checkWard);
 
@@ -206,7 +207,7 @@ namespace ValheimPlus
             List<ItemDrop.ItemData> allItems = GetNearbyChestItemsByContainerList(nearbyChests);
 
             // get amount of item
-            int availableAmount = GetItemAmountInItemList(allItems, needle);
+            int availableAmount = GetItemAmountInItemList(allItems, itemNameToRemove);
 
             // check if there are enough items
             if (amount == 0)
@@ -218,7 +219,7 @@ namespace ValheimPlus
             {
                 if (itemsRemovedTotal != amount)
                 {
-                    int removedItems = RemoveItemFromChest(chest, needle, amount);
+                    int removedItems = RemoveItemFromChest(chest, itemNameToRemove, amount);
                     itemsRemovedTotal += removedItems;
                     amount -= removedItems;
                 }
@@ -232,76 +233,82 @@ namespace ValheimPlus
         /// <summary>
         /// Removes the specified amount of a item found by m_shared.m_name by the declared amount
         /// </summary>
-        public static int RemoveItemFromChest(Container chest, ItemDrop.ItemData needle, int amount = 1)
+        public static int RemoveItemFromChest(Container chest, ItemDrop.ItemData itemDataToRemove, int amount = 1)
         {
-            if (!ChestContainsItem(chest, needle))
+            if (chest.IsInUse() || !ChestContainsItem(chest, itemDataToRemove))
             {
                 return 0;
             }
 
-            int totalRemoved = 0;
-            // find item
-            List<ItemDrop.ItemData> allItems = chest.GetInventory().GetAllItems();
-            foreach (ItemDrop.ItemData itemData in allItems)
+            using (InventoryAssistant.lockContainer(chest))
             {
-                if (itemData.m_shared.m_name == needle.m_shared.m_name)
+                int totalRemoved = 0;
+                // find item
+                List<ItemDrop.ItemData> allItems = chest.GetInventory().GetAllItems();
+                foreach (ItemDrop.ItemData itemData in allItems)
                 {
-                    int num = Mathf.Min(itemData.m_stack, amount);
-                    itemData.m_stack -= num;
-                    amount -= num;
-                    totalRemoved += num;
-                    if (amount <= 0)
+                    if (itemData.m_shared.m_name == itemDataToRemove.m_shared.m_name)
                     {
-                        break;
+                        int num = Mathf.Min(itemData.m_stack, amount);
+                        itemData.m_stack -= num;
+                        amount -= num;
+                        totalRemoved += num;
+                        if (amount <= 0)
+                        {
+                            break;
+                        }
                     }
                 }
+
+                // We don't want to send chest content through network
+                if (totalRemoved == 0) return 0;
+
+                allItems.RemoveAll((ItemDrop.ItemData x) => x.m_stack <= 0);
+                chest.m_inventory.m_inventory = allItems;
+
+                ConveyContainerToNetwork(chest);
+
+                return totalRemoved;
             }
-
-            // We don't want to send chest content through network
-            if (totalRemoved == 0) return 0;
-
-            allItems.RemoveAll((ItemDrop.ItemData x) => x.m_stack <= 0);
-            chest.m_inventory.m_inventory = allItems;
-
-            ConveyContainerToNetwork(chest);
-
-            return totalRemoved;
         }
 
-        public static int RemoveItemFromChest(Container chest, string needle, int amount = 1)
+        public static int RemoveItemFromChest(Container chest, string itemNameToRemove, int amount = 1)
         {
-            if (!ChestContainsItem(chest, needle))
+            if (chest.IsInUse() || !ChestContainsItem(chest, itemNameToRemove))
             {
                 return 0;
             }
 
-            int totalRemoved = 0;
-            // find item
-            List<ItemDrop.ItemData> allItems = chest.GetInventory().GetAllItems();
-            foreach (ItemDrop.ItemData itemData in allItems)
+            using (InventoryAssistant.lockContainer(chest))
             {
-                if (itemData.m_shared.m_name == needle)
+                int totalRemoved = 0;
+                // find item
+                List<ItemDrop.ItemData> allItems = chest.GetInventory().GetAllItems();
+                foreach (ItemDrop.ItemData itemData in allItems)
                 {
-                    int num = Mathf.Min(itemData.m_stack, amount);
-                    itemData.m_stack -= num;
-                    amount -= num;
-                    totalRemoved += num;
-                    if (amount <= 0)
+                    if (itemData.m_shared.m_name == itemNameToRemove)
                     {
-                        break;
+                        int num = Mathf.Min(itemData.m_stack, amount);
+                        itemData.m_stack -= num;
+                        amount -= num;
+                        totalRemoved += num;
+                        if (amount <= 0)
+                        {
+                            break;
+                        }
                     }
                 }
+
+                // We don't want to send chest content through network
+                if (totalRemoved == 0) return 0;
+
+                allItems.RemoveAll((ItemDrop.ItemData x) => x.m_stack <= 0);
+                chest.m_inventory.m_inventory = allItems;
+
+                ConveyContainerToNetwork(chest);
+
+                return totalRemoved;
             }
-
-            // We don't want to send chest content through network
-            if (totalRemoved == 0) return 0;
-
-            allItems.RemoveAll((ItemDrop.ItemData x) => x.m_stack <= 0);
-            chest.m_inventory.m_inventory = allItems;
-
-            ConveyContainerToNetwork(chest);
-
-            return totalRemoved;
         }
 
         /// <summary>
@@ -311,6 +318,54 @@ namespace ValheimPlus
         {
             c.Save();
             c.GetInventory().Changed();
+        }
+
+        /// <summary>
+        /// To be used in a using statement during mutating operations.
+        /// This will set the container to in use for the duration of the code within the using block.
+        /// This will lock players out of the container while the code in the using statement is ran so that 
+        /// their changes don't get overwritten by mod changes. Make sure to check that the container is not in use 
+        /// before locking it.
+        /// 
+        /// Sample:
+        /// <code>
+        /// if (chest.IsInUse()) 
+        /// 	continue;
+        /// using (InventoryAssistant.lockContainer(chest))
+        /// {
+        /// 	// modify container
+        /// 	InventoryAssistant.ConveyContainerToNetwork(chest);
+        /// }
+        /// </code>
+        /// 
+        /// </summary>
+        /// <param name="container">the container to lock</param>
+        /// <returns>a disposable that will unlock the container at the end of the using statement</returns>
+        public static IDisposable lockContainer(Container container)
+        {
+            return new ContainerDisposable(container);
+        }
+
+        private class ContainerDisposable : IDisposable
+        {
+            private readonly Container m_container;
+
+            public ContainerDisposable(Container container)
+            {
+                m_container = container;
+                if (m_container.IsInUse())
+                    ZLog.LogWarning("Locking a container that was already locked. This may result in overwriting container changes.");
+                else
+                    m_container.SetInUse(true);
+            }
+
+            public void Dispose()
+            {
+                if (!m_container.IsInUse())
+                    ZLog.LogWarning("Unlocking a container that was already unlocked. There may have been overwriting container changes.");
+                else
+                    m_container.SetInUse(false);
+            }
         }
     }
 }


### PR DESCRIPTION
Updates any container modification to check is the container is in use by a player. If it is, then the container is ineligible for modifications. If it is not, it is set to "in use" while the mod changes the contents, and then sets it back to not in use after. 

These changes aren't very well tested, I did verify that chests being used by players are skipped, but I couldn't reproduce a player being locked out of a chest while the mod changes it (since the time window is so small).

This is mostly an example of what I was thinking in [my comment on #675](https://github.com/valheimPlus/ValheimPlus/issues/675#issuecomment-1431925913) to avoid players putting items into a chest, only for them to be overwritten by the mod also depositing items.