### PR TITLE
Fixing compile and patch errors introduced via v0.214.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## How to setup your environment for V+ development
 How to setup the development enviroment to compile ValheimPlus yourself.
 
-1. Download the [BepInEx for Valheim package](https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.1901/).
+1. Download the [BepInEx for Valheim package](https://valheim.thunderstore.io/package/download/denikson/BepInExPack_Valheim/5.4.2100/).
    - Extract zip contents and copy the contents inside `/BepInExPack_Valheim/` and paste them in your Valheim root folder and overwrite every file when asked.
    - This package sets up your Valheim game with BepInEx configurations specifically for mod devs. Created by [BepInEx](https://github.com/BepInEx).
 1. Copy over all the DLLs from Valheim/unstripped_corlib to Valheim/valheim_Data/Managed *(overwrite when asked)*

--- a/ValheimPlus/GameClasses/Chat.cs
+++ b/ValheimPlus/GameClasses/Chat.cs
@@ -10,10 +10,10 @@ namespace ValheimPlus.GameClasses
     /// <summary>
     /// Change Ping and global message behavior
     /// </summary>
-    [HarmonyPatch(typeof(Chat), nameof(Chat.OnNewChatMessage), new System.Type[] { typeof(GameObject), typeof(long), typeof(Vector3), typeof(Talker.Type), typeof(string), typeof(string), typeof(string) })]
+    [HarmonyPatch(typeof(Chat), nameof(Chat.OnNewChatMessage), new System.Type[] { typeof(GameObject), typeof(long), typeof(Vector3), typeof(Talker.Type), typeof(UserInfo), typeof(string), typeof(string) })]
     public static class Chat_AddInworldText_Patch
     {
-        private static bool Prefix(ref Chat __instance, GameObject go, long senderID, Vector3 pos, Talker.Type type, string user, string text, string senderNetworkUserId)
+        private static bool Prefix(ref Chat __instance, GameObject go, long senderID, Vector3 pos, Talker.Type type, UserInfo user, string text, string senderNetworkUserId)
         {
 
             if (Configuration.Current.Chat.IsEnabled)
@@ -50,7 +50,7 @@ namespace ValheimPlus.GameClasses
                     {
                         // Only add string to chat window and show no ping
                         if (Configuration.Current.Chat.outOfRangeShoutsDisplayInChatWindow)
-                            __instance.AddString(user, text, Talker.Type.Shout);
+                            __instance.AddString(user.GetDisplayName(senderNetworkUserId), text, Talker.Type.Shout);
                         return false;
                     }
                 }
@@ -64,7 +64,7 @@ namespace ValheimPlus.GameClasses
 
 
 
-    [HarmonyPatch(typeof(Chat), nameof(Chat.AddInworldText), new System.Type[] { typeof(GameObject), typeof(long), typeof(Vector3), typeof(Talker.Type), typeof(string), typeof(string) })]
+    [HarmonyPatch(typeof(Chat), nameof(Chat.AddInworldText), new System.Type[] { typeof(GameObject), typeof(long), typeof(Vector3), typeof(Talker.Type), typeof(UserInfo), typeof(string) })]
     public static class Chat_AddInworldText_Transpiler
     {
         /// <summary>

--- a/ValheimPlus/GameClasses/InventoryGUI.cs
+++ b/ValheimPlus/GameClasses/InventoryGUI.cs
@@ -261,7 +261,8 @@ namespace ValheimPlus.GameClasses
 
         private static ItemDrop.ItemData GetFirstRequiredItemFromInventoryOrChest(Player player, Recipe recipe, int quality, out int quantity)
         {
-            ItemDrop.ItemData found = player.GetFirstRequiredItem(player.GetInventory(), recipe, quality, out quantity);
+            int extraAmount;
+            ItemDrop.ItemData found = player.GetFirstRequiredItem(player.GetInventory(), recipe, quality, out quantity, out extraAmount);
             if (found != null) return found;
 
             GameObject pos = player.GetCurrentCraftingStation()?.gameObject;
@@ -271,7 +272,7 @@ namespace ValheimPlus.GameClasses
 
             foreach (Container chest in nearbyChests)
             {
-                found = player.GetFirstRequiredItem(chest.GetInventory(), recipe, quality, out quantity);
+                found = player.GetFirstRequiredItem(chest.GetInventory(), recipe, quality, out quantity, out extraAmount);
                 if (found != null)
                 {
                     return found;


### PR DESCRIPTION
Possibly fixes #789, #790, #791, #792. Unclear if there are any incompatibilities in `Valheim v0.214.2` that didn't cause obvious errors. 

Upgrading `BepInExPack_Valheim` to `5.4.2100` was required. Without it, there were additional errors when using the console or chat, seemingly because of missing `unstripped_corlib` dependencies that were added in the new Valheim version.

I tested the use cases mentioned not working in the linked issues with some exceptions: 
* server sync config
* ABM
* Structural integrity

Given that most of the problems were fixed from changes in mostly unrelated code, I think it is *not terribly risky* to say it was the root cause. 

---

Edit: Since this seems like it may be sitting a while, I uploaded this change to [thunderstore](https://valheim.thunderstore.io/package/Grantapher/ValheimPlus_Grantapher_Temporary/) for folks who install from there and [added a release on my fork](https://github.com/Grantapher/ValheimPlus/releases/tag/0.9.9.12) for folks who install manually. The regular installation instructions will apply to that release.

They both contain [one additional change](https://github.com/Grantapher/ValheimPlus/commit/d01273233c8d29eedb4d037cb785846ded7b77aa) that bumps up the version number, points some version/config checks to my fork, and adds the fact that it is not the main mod to the title screen text. The branch used is the one attached to that commit: [grantapher-development](https://github.com/valheimPlus/ValheimPlus/compare/development...Grantapher:ValheimPlus:grantapher-development).