### PR TITLE
Fix hotkey sync

### DIFF
--- a/ValheimPlus/Configurations/BaseConfig.cs
+++ b/ValheimPlus/Configurations/BaseConfig.cs
@@ -1,15 +1,19 @@
 using IniParser.Model;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
+using ValheimPlus.RPC;
+using YamlDotNet.Core.Tokens;
+using static CharacterDrop;
 
 namespace ValheimPlus.Configurations
 {
     public interface IConfig
     {
-        void LoadIniData(KeyDataCollection data);
+        void LoadIniData(KeyDataCollection data, string section);
     }
 
-    public abstract class BaseConfig<T> : IConfig where T : IConfig, new()
+    public abstract class BaseConfig<T> : IConfig where T : class, IConfig, new()
     {
 
         public string ServerSerializeSection()
@@ -25,8 +29,8 @@ namespace ValheimPlus.Configurations
             return r;
         }
 
-        public bool IsEnabled = false;
-        public virtual bool NeedsServerSync { get; set;} = false;
+        public bool IsEnabled { get; private set; } = false;
+        public virtual bool NeedsServerSync { get; set; } = false;
 
         public static IniData iniUpdated = null;
 
@@ -34,72 +38,106 @@ namespace ValheimPlus.Configurations
         {
             var n = new T();
 
-            
+
             Debug.Log($"Loading config section {section}");
             if (data[section] == null || data[section]["enabled"] == null || !data[section].GetBool("enabled"))
             {
                 Debug.Log(" Section not enabled");
                 return n;
             }
-
-            n.LoadIniData(data[section]);
+            var keyData = data[section];
+            n.LoadIniData(keyData, section);
 
             return n;
         }
 
-        public void LoadIniData(KeyDataCollection data)
+        public void LoadIniData(KeyDataCollection data, string section)
         {
             IsEnabled = true;
-
-            foreach (var prop in typeof(T).GetProperties())
+            var thisConfiguration = GetCurrentConfiguration(section);
+            if (thisConfiguration == null)
             {
-                var keyName = prop.Name;
+                Debug.Log("Configuration not set.");
+                thisConfiguration = this as T;
+                if (thisConfiguration == null) Debug.Log("Error on setting Configuration");
+            }
+
+            foreach (var property in typeof(T).GetProperties())
+            {
+                var keyName = property.Name;
                 if (new[] { "NeedsServerSync", "IsEnabled" }.Contains(keyName)) continue;
+                var currentValue = property.GetValue(thisConfiguration);
                 // Set first char of keyName to lowercase
                 if (keyName != string.Empty && char.IsUpper(keyName[0]))
                 {
                     keyName = char.ToLower(keyName[0]) + keyName.Substring(1);
                 }
 
-                if (!data.ContainsKey(keyName)) {
+                if (!data.ContainsKey(keyName))
+                {
                     Debug.Log($" Key {keyName} not defined, using default value");
                     continue;
                 }
 
                 Debug.Log($" Loading key {keyName}");
-                var existingValue = prop.GetValue(this, null);
 
-                if (prop.PropertyType == typeof(float))
+                Debug.Log($"{property.Name} [{keyName}] = {currentValue} ({property.PropertyType})");
+                if (property.PropertyType == typeof(float))
                 {
-                    prop.SetValue(this, data.GetFloat(keyName, (float)existingValue), null);
+                    var value = data.GetFloat(keyName, (float)currentValue);
+                    Debug.Log($"{keyName} = {currentValue} => {value}");
+
+                    property.SetValue(this, value, null);
                     continue;
                 }
 
-                if (prop.PropertyType == typeof(int))
+                if (property.PropertyType == typeof(int))
                 {
-                    prop.SetValue(this, data.GetInt(keyName, (int)existingValue), null);
+                    var value = data.GetInt(keyName, (int)currentValue);
+                    Debug.Log($"{keyName} = {currentValue} => {value}");
+                    property.SetValue(this, data.GetInt(keyName, (int)currentValue), null);
                     continue;
                 }
 
-                if (prop.PropertyType == typeof(bool))
+                if (property.PropertyType == typeof(bool))
                 {
-                    prop.SetValue(this, data.GetBool(keyName), null);
+                    var value = data.GetBool(keyName);
+                    Debug.Log($"{keyName} = {currentValue} => {value}");
+                    property.SetValue(this, value, null);
                     continue;
                 }
 
-                if (prop.PropertyType == typeof(KeyCode) && !RPC.VPlusConfigSync.isConnecting)
+                if (property.PropertyType == typeof(KeyCode))
                 {
-                    prop.SetValue(this, data.GetKeyCode(keyName, (KeyCode)existingValue), null);
+                    Debug.Log($"Setting Hotkey is {(ConfigurationExtra.ReadHotKeys ? "enabled" : "disabled")}");
+                    var newValue = ConfigurationExtra.ReadHotKeys ? data.GetKeyCode(keyName, (KeyCode)currentValue) : (KeyCode)currentValue;
+                    Debug.Log($"{keyName} = {currentValue} => {newValue}");
+                    property.SetValue(this, newValue, null);
                     continue;
                 }
 
-                Debug.LogWarning($" Could not load data of type {prop.PropertyType} for key {keyName}");
+                Debug.LogWarning($" Could not load data of type {property.PropertyType} for key {keyName}");
             }
         }
 
+        private static object GetCurrentConfiguration(string section)
+        {
+            if (Configuration.Current == null) return null;
+            Debug.Log($"Reading Config '{section}'");
+            var properties = Configuration.Current.GetType().GetProperties();
+            PropertyInfo property = properties.SingleOrDefault(p => p.Name.Equals(section, System.StringComparison.CurrentCultureIgnoreCase));
+            if (property == null)
+            {
+                Debug.LogWarning($"Property '{section}' not found in Configuration");
+                return null;
+            }
+            var thisConfiguration = property.GetValue(Configuration.Current) as T;
+            return thisConfiguration;
+        }
     }
 
-    public abstract class ServerSyncConfig<T>: BaseConfig<T> where T : IConfig, new() {
-        public override bool NeedsServerSync { get; set;} = true;
+    public abstract class ServerSyncConfig<T> : BaseConfig<T> where T : class, IConfig, new()
+    {
+        public override bool NeedsServerSync { get; set; } = true;
     }
 }

--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using IniParser;
 using IniParser.Model;
 using System;
@@ -9,6 +9,8 @@ using System.Linq;
 using System.Reflection;
 using UnityEngine;
 using ValheimPlus.Utility;
+using ValheimPlus.Configurations.Sections;
+using ValheimPlus.RPC;
 
 namespace ValheimPlus.Configurations
 {
@@ -21,7 +23,7 @@ namespace ValheimPlus.Configurations
             {
                 var keyName = prop.Name;
                 var method = prop.PropertyType.GetMethod("ServerSerializeSection", BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
-                
+
                 if (method != null)
                 {
                     var instance = prop.GetValue(config, null);
@@ -50,7 +52,7 @@ namespace ValheimPlus.Configurations
                         // get the current versions ini data
                         compareIni = ValheimPlusPlugin.getCurrentWebIniFile();
                     }
-                    catch (Exception e) { }
+                    catch (Exception) { }
 
                     if (compareIni != null)
                     {
@@ -75,7 +77,7 @@ namespace ValheimPlus.Configurations
                     try
                     {
                         string defaultIni = ValheimPlusPlugin.getCurrentWebIniFile();
-                        if(defaultIni != null)
+                        if (defaultIni != null)
                         {
                             System.IO.File.WriteAllText(ConfigIniPath, defaultIni);
                             Debug.Log("Default Configuration downloaded. Loading downloaded default settings.");
@@ -83,7 +85,7 @@ namespace ValheimPlus.Configurations
                             status = true;
                         }
                     }
-                    catch (Exception e) { }
+                    catch (Exception) { }
 
                     return status;
                 }
@@ -96,12 +98,13 @@ namespace ValheimPlus.Configurations
 
             return true;
         }
+        static public bool ReadHotKeys { get; private set; } = true;
 
         public static Configuration LoadFromIni(string filename)
         {
             FileIniDataParser parser = new FileIniDataParser();
             IniData configdata = parser.ReadFile(filename);
-
+            ReadHotKeys = true;
             Configuration conf = new Configuration();
             foreach (var prop in typeof(Configuration).GetProperties())
             {
@@ -124,6 +127,15 @@ namespace ValheimPlus.Configurations
             {
                 FileIniDataParser parser = new FileIniDataParser();
                 IniData configdata = parser.ReadData(iniReader);
+                var serverSection = configdata[nameof(Configuration.Server)];
+                var serverSyncsConfig = serverSection.GetBool(nameof(ServerConfiguration.serverSyncsConfig));
+                Debug.Log($"ServerSyncsConfig = {serverSyncsConfig}");
+
+                if (!serverSyncsConfig) return Configuration.Current;
+
+                var serverSyncsHotkeys = serverSection.GetBool(nameof(ServerConfiguration.serverSyncHotkeys));
+                Debug.Log($"ServerSyncsHotkeys = {serverSyncsConfig}");
+                ReadHotKeys = serverSyncsHotkeys;
 
                 Configuration conf = new Configuration();
                 foreach (var prop in typeof(Configuration).GetProperties())
@@ -134,7 +146,7 @@ namespace ValheimPlus.Configurations
 
                     if (method != null)
                     {
-                        object result = method.Invoke(null, new object[] {configdata, keyName});
+                        object result = method.Invoke(null, new object[] { configdata, keyName });
                         prop.SetValue(conf, result, null);
                     }
                 }
@@ -147,7 +159,8 @@ namespace ValheimPlus.Configurations
     {
         public static float GetFloat(this KeyDataCollection data, string key, float defaultVal)
         {
-            if (float.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result)) { 
+            if (float.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result))
+            {
                 return result;
             }
 
@@ -163,7 +176,8 @@ namespace ValheimPlus.Configurations
 
         public static int GetInt(this KeyDataCollection data, string key, int defaultVal)
         {
-            if (int.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result)) { 
+            if (int.TryParse(data[key], NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat, out var result))
+            {
                 return result;
             }
 
@@ -173,7 +187,8 @@ namespace ValheimPlus.Configurations
 
         public static KeyCode GetKeyCode(this KeyDataCollection data, string key, KeyCode defaultVal)
         {
-            if (Enum.TryParse<KeyCode>(data[key].Trim(), out var result)) {
+            if (Enum.TryParse<KeyCode>(data[key].Trim(), out var result))
+            {
                 return result;
             }
 

--- a/ValheimPlus/RPC/VPlusConfigSync.cs
+++ b/ValheimPlus/RPC/VPlusConfigSync.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using BepInEx;
 using ValheimPlus.Configurations;
@@ -8,7 +8,6 @@ namespace ValheimPlus.RPC
     public class VPlusConfigSync
     {
 
-        static public bool isConnecting = false;
         public static void RPC_VPlusConfigSync(long sender, ZPackage configPkg)
         {
             if (ZNet.m_isServer) //Server
@@ -49,8 +48,8 @@ namespace ValheimPlus.RPC
             }
             else //Client
             {
-                if (configPkg != null && 
-                    configPkg.Size() > 0 && 
+                if (configPkg != null &&
+                    configPkg.Size() > 0 &&
                     sender == ZRoutedRpc.instance.GetServerPeerID()) //Validate the message is from the server and not another client.
                 {
                     int numLines = configPkg.ReadInt();
@@ -76,19 +75,8 @@ namespace ValheimPlus.RPC
                             memStream.Position = 0; //Rewind stream
 
                             ValheimPlusPlugin.harmony.UnpatchSelf();
+                            Configuration.Current = ConfigurationExtra.LoadFromIni(memStream);
 
-                            // Sync HotKeys when connecting ?
-                            if(Configuration.Current.Server.IsEnabled && !Configuration.Current.Server.serverSyncHotkeys)
-                            {
-                                isConnecting = true;
-                                Configuration.Current = ConfigurationExtra.LoadFromIni(memStream);
-                                isConnecting = false;
-                            }
-                            else
-                            {
-                                Configuration.Current = ConfigurationExtra.LoadFromIni(memStream);
-                            }
-                                
                             ValheimPlusPlugin.harmony.PatchAll();
 
                             ZLog.Log("Successfully synced VPlus configuration from server.");


### PR DESCRIPTION
#801

Local Hotkeys were always been overwritten: by server or by default, because on sync local settings was been ignored
Addition fix: Sync-Options will be used from server config, instead from local config